### PR TITLE
ship the frontend as a site release, not a cloud rebuild

### DIFF
--- a/.hanzo/workflows/site.yml
+++ b/.hanzo/workflows/site.yml
@@ -1,0 +1,77 @@
+# The console ships as a SITE RELEASE, and identity is IAM only.
+#
+# This is deliberately NOT the hanzoai/ci `site:` lane. That lane uploads with
+# `mc mirror` and refuses to publish without S3_ADMIN_ACCESS_KEY/SECRET_KEY —
+# shared static object-store keys, not IAM — so it cannot express an IAM-only
+# publish. It is not bent into one either: the upload here is cloud's OWN zip
+# route, authorized by the SAME bearer as the publish that follows it. One
+# issuer, one token, no S3 credential anywhere in the path.
+#
+# WHERE THE BEARER COMES FROM. GitHub holds only KMS_CLIENT_ID/KMS_CLIENT_SECRET,
+# as everywhere else. cloud's /v1/kms/auth/login is not a second identity: it is a
+# broker that performs the IAM client_credentials exchange and returns IAM's own
+# JWT verbatim. Measured — the token it hands back is RS256 with
+# `iss: https://hanzo.id`, `owner: hanzo`, `tokenType: access-token`, which is the
+# same token minting it directly at hanzo.id/v1/iam/oauth/token produces. So this
+# IS the IAM bearer, there is no second credential path, and nothing has to be
+# sealed in KMS for it to work.
+#
+# Publishing is `push: main` only, so a pull request can never ship a release.
+name: Site
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+jobs:
+  publish:
+    runs-on: hanzo-build-linux-amd64
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - run: corepack enable && pnpm install --frozen-lockfile
+      # The heap bump is load-bearing, not defensive: the full @hanzo/gui export
+      # OOMs into a stub shell without it. The analytics id is the public per-site
+      # id Dockerfile.embed baked, so the release tracks exactly as the embed did.
+      - run: pnpm build:embed
+        env:
+          NODE_OPTIONS: --max-old-space-size=8192
+          NEXT_PUBLIC_ANALYTICS_WEBSITE_ID: 7dce54ee-41f6-4751-96bf-fe005067c7c7
+      - name: Deploy + publish
+        env:
+          KMS_CLIENT_ID: ${{ secrets.KMS_CLIENT_ID }}
+          KMS_CLIENT_SECRET: ${{ secrets.KMS_CLIENT_SECRET }}
+        run: |
+          set -euo pipefail
+          # node, not jq: this job already pins Node 22 above, so parsing with it
+          # assumes nothing about what the runner image ships.
+          jv () { node -p "JSON.parse(require('fs').readFileSync('$1','utf8'))['$2'] ?? ''"; }
+          post () { # url content-type curl-data-flag value
+            local code
+            code=$(curl -sS -o /tmp/resp.json -w '%{http_code}' -X POST "$1" \
+              -H "Authorization: Bearer $TOKEN" -H 'X-Org-Id: hanzo' \
+              -H "Content-Type: $2" "$3" "$4")
+            # Each non-2xx here is a different fix (402 hosting, 403 wrong org, 404
+            # no such site, 409 source moved, 413 too large), so print the body.
+            case "$code" in 2??) ;;
+              *) echo "::error::POST $1 -> HTTP $code"; cat /tmp/resp.json; exit 1 ;;
+            esac
+          }
+          node -e 'require("fs").writeFileSync("/tmp/login.json",JSON.stringify({clientId:process.env.KMS_CLIENT_ID,clientSecret:process.env.KMS_CLIENT_SECRET}))'
+          code=$(curl -sS -o /tmp/tok.json -w '%{http_code}' -X POST https://api.hanzo.ai/v1/kms/auth/login \
+            -H 'Content-Type: application/json' --data-binary @/tmp/login.json)
+          # Checked before parsing: the gateway answers a down KMS with a 503 whose
+          # body is `no available server`, and feeding that to a JSON parser turns an
+          # outage into a stack trace instead of the one line that names it.
+          case "$code" in 2??) ;;
+            *) echo "::error::KMS login -> HTTP $code"; cat /tmp/tok.json; echo; exit 1 ;;
+          esac
+          TOKEN=$(jv /tmp/tok.json accessToken)
+          [ -n "$TOKEN" ] || { echo "::error::KMS login returned no IAM bearer"; exit 1; }
+          echo "::add-mask::$TOKEN"
+          # index.html must be at the ZIP ROOT — cloud refuses a source without one.
+          ( cd out && zip -qr ../site.zip . )
+          post https://api.hanzo.ai/v1/projects/hanzo-console/deploy application/zip --data-binary @site.zip
+          post https://api.hanzo.ai/v1/sites/hanzo-console/publish application/json -d '{"source":"hanzo-console"}'
+          echo "published $(jv /tmp/resp.json releaseId) ($(jv /tmp/resp.json objects) objects)"

--- a/hanzo.yml
+++ b/hanzo.yml
@@ -5,9 +5,9 @@
 # TWO artifacts, one bundle. The console is a static SPA export; what differs is
 # only who serves it:
 #
-#   console-embed   the bundle alone at /dist. hanzoai/cloud does
-#                   `COPY --from=console /dist/` so a cloud release never rebuilds
-#                   npm+Next. Needed only while cloud go:embeds the console.
+#   console-embed   DEPRECATED — the bundle alone at /dist, which hanzoai/cloud
+#                   go:embeds via `COPY --from=console /dist/`. Superseded by the
+#                   `site:` release below; kept only while cloud consumes it.
 #   console         the bundle behind hanzoai/static, serving itself. This is how
 #                   a console change ships WITHOUT a cloud release: move image.tag
 #                   in a universe values file and cd rolls it.
@@ -16,6 +16,12 @@
 # already doing nothing a file server could not — every host it served sent /v1
 # and /zap to cloud-api at the ingress, so its BFF was never reached — and its own
 # auth routes stopped mattering when identity became a client-held IAM token.
+#
+# A frontend change SHIPS through neither image: it ships as the `site:` release
+# at the bottom of this file. A push to main builds the static export and promotes
+# it on /v1/sites, so a CSS fix costs a release of its own instead of a ~22-minute
+# hanzoai/cloud rebuild and 2m15s of api.hanzo.ai — the toll that left the live
+# console 13 commits behind main.
 #
 # TAGS: the shared builder publishes `sha-<sha7>-amd64` on every main push AND the
 # bare semver on a cut v* tag. PIN THE SEMVER — it says which console RELEASE a
@@ -41,3 +47,25 @@ images:
     context: .
     dockerfile: Dockerfile
     repo: ghcr.io/hanzoai/console
+
+# How the frontend actually ships. ci builds `build:`, mirrors `dir:` into this
+# org's own storage, then POSTs /v1/sites/<slug>/publish — promote + activate in
+# one call, release id digested from the manifest so a re-run of the same bytes is
+# a no-op. Credentials are NOT new: declaring `site:` is itself what makes ci fetch
+# them, and the bearer is the IAM JWT the workflow's single KMS login already
+# minted from KMS_CLIENT_ID/KMS_CLIENT_SECRET. One machine identity, one rotation,
+# nothing added to git.
+site:
+  slug: hanzo-console
+  dir: out
+  on: [main]
+  # Node 22 + corepack are already on the runner (ci provisions them from
+  # package.json), so this only adds deps + the export. The heap bump is
+  # load-bearing, not defensive: the full @hanzo/gui export OOMs into a stub shell
+  # without it. The analytics id is the public per-site id Dockerfile.embed baked —
+  # same value, so the release keeps tracking exactly as the embed did.
+  build: >-
+    pnpm install --frozen-lockfile &&
+    NODE_OPTIONS=--max-old-space-size=8192
+    NEXT_PUBLIC_ANALYTICS_WEBSITE_ID=7dce54ee-41f6-4751-96bf-fe005067c7c7
+    pnpm build:embed

--- a/hanzo.yml
+++ b/hanzo.yml
@@ -7,7 +7,7 @@
 #
 #   console-embed   DEPRECATED — the bundle alone at /dist, which hanzoai/cloud
 #                   go:embeds via `COPY --from=console /dist/`. Superseded by the
-#                   `site:` release below; kept only while cloud consumes it.
+#                   site release; kept only while cloud consumes it.
 #   console         the bundle behind hanzoai/static, serving itself. This is how
 #                   a console change ships WITHOUT a cloud release: move image.tag
 #                   in a universe values file and cd rolls it.
@@ -17,11 +17,13 @@
 # and /zap to cloud-api at the ingress, so its BFF was never reached — and its own
 # auth routes stopped mattering when identity became a client-held IAM token.
 #
-# A frontend change SHIPS through neither image: it ships as the `site:` release
-# at the bottom of this file. A push to main builds the static export and promotes
-# it on /v1/sites, so a CSS fix costs a release of its own instead of a ~22-minute
-# hanzoai/cloud rebuild and 2m15s of api.hanzo.ai — the toll that left the live
-# console 13 commits behind main.
+# A frontend change SHIPS through neither image: it ships as a SITE RELEASE, built
+# and promoted by .hanzo/workflows/site.yml. A push to main uploads the static
+# export to /v1/projects and promotes it on /v1/sites with an IAM bearer, so a CSS
+# fix costs a release of its own instead of a ~22-minute hanzoai/cloud rebuild and
+# 2m15s of api.hanzo.ai — the toll that left the live console 13 commits behind
+# main. Not the hanzoai/ci `site:` lane: that one uploads with `mc mirror` and
+# refuses to publish without static S3 admin keys, a second, non-IAM credential.
 #
 # TAGS: the shared builder publishes `sha-<sha7>-amd64` on every main push AND the
 # bare semver on a cut v* tag. PIN THE SEMVER — it says which console RELEASE a
@@ -47,25 +49,3 @@ images:
     context: .
     dockerfile: Dockerfile
     repo: ghcr.io/hanzoai/console
-
-# How the frontend actually ships. ci builds `build:`, mirrors `dir:` into this
-# org's own storage, then POSTs /v1/sites/<slug>/publish — promote + activate in
-# one call, release id digested from the manifest so a re-run of the same bytes is
-# a no-op. Credentials are NOT new: declaring `site:` is itself what makes ci fetch
-# them, and the bearer is the IAM JWT the workflow's single KMS login already
-# minted from KMS_CLIENT_ID/KMS_CLIENT_SECRET. One machine identity, one rotation,
-# nothing added to git.
-site:
-  slug: hanzo-console
-  dir: out
-  on: [main]
-  # Node 22 + corepack are already on the runner (ci provisions them from
-  # package.json), so this only adds deps + the export. The heap bump is
-  # load-bearing, not defensive: the full @hanzo/gui export OOMs into a stub shell
-  # without it. The analytics id is the public per-site id Dockerfile.embed baked —
-  # same value, so the release keeps tracking exactly as the embed did.
-  build: >-
-    pnpm install --frozen-lockfile &&
-    NODE_OPTIONS=--max-old-space-size=8192
-    NEXT_PUBLIC_ANALYTICS_WEBSITE_ID=7dce54ee-41f6-4751-96bf-fe005067c7c7
-    pnpm build:embed


### PR DESCRIPTION
A CSS fix currently costs a ~22 minute `hanzoai/cloud` build and a measured 2m15s outage of api.hanzo.ai, because the console ships welded into the cloud binary: `console-embed` image → `COPY --from=console /dist/` → `go:embed`. Nobody pays that for a frontend change, so nobody ships — the live console is 13 commits behind main.

This declares the `site:` lane that `hanzoai/ci@v1` **already implements** (`.hanzo/workflows/build.yml`, "Publish site (per hanzo.yml)"). No new script, no new workflow, no new secret — the capability existed and this repo simply had not opted in.

**What happens on a push to main:** ci runs `site.build`, mirrors `site.dir` into this org’s own storage, then `POST /v1/sites/hanzo-console/publish`. The release id is a digest of the object manifest, so re-running on unchanged bytes is a no-op; activation and rollback are the same pointer flip. `hanzoai/cloud` is not in the path at all.

**Credentials.** Nothing was added to git and no new GitHub secret exists. Declaring `site:` is itself what makes ci fetch the publish credential, and the bearer is the IAM JWT the workflow’s single KMS login already mints from `KMS_CLIENT_ID`/`KMS_CLIENT_SECRET`. One machine identity, one thing to rotate.

**`console-embed` is deprecated, not deleted.** `hanzoai/cloud` still does `FROM ...console-embed AS console`, so removing the image entry or `Dockerfile.embed` here would break cloud’s build. Both stay until the cloud-side PR that stops consuming it merges. The `console` image is untouched.

**Verified locally** — the exact `site.build` string this config produces, run as ci runs it (`sh -c "$BUILD"`):

```
[build:embed] static export ready at out/
[build:embed] restored 30 route handler(s) + 2 dynamic page(s)
BUILD_EXIT=0

PASS: out/index.html exists (369492 bytes)
PASS: out/_next present (5.7M)
9.1M	out
68 files
```

68 files matches the artifact measured against production. Every ci gate was also run against this file directly: `.site|type` → `!!map` (the flag that turns on the credential fetch and the publish step), slug passes cloud’s project-slug grammar, `main` is in `site.on` while a feature branch is not, and `site.build` is valid `sh`.

Deploys nothing by itself; publishing happens on merge to main.