### PR TITLE
the console names its API host instead of inheriting it

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -128,6 +128,20 @@ export type ConsoleConfig = {
   shell: ShellId
 }
 
+/**
+ * THE API host. Every `/v1` call in this app resolves against this one string —
+ * there is no second endpoint and no per-brand API host (a brand differs by its
+ * IAM issuer and its wordmark, never by where its data lives; the cloud backend is
+ * ONE multi-tenant `/v1`, scoped by the brand JWT's org).
+ *
+ * It is absolute, not `window.location.origin`. Same-origin *looked* compliant only
+ * because console.hanzo.ai and api.hanzo.ai are the same binary on the same address
+ * — an accident of topology, not a property of the code. Naming the host makes the
+ * contract true by construction: relocate the SPA to any origin and it still calls
+ * the canonical API.
+ */
+export const CANONICAL_API_URL = 'https://api.hanzo.ai'
+
 /** Fields shared by every brand. Env-overridable per-deploy. */
 const PLATFORM_URL = trimSlash(process.env.NEXT_PUBLIC_PLATFORM_URL ?? 'https://platform.hanzo.ai')
 const SHARED = {
@@ -136,28 +150,41 @@ const SHARED = {
   // PaaS deploy flow's templates surface; repoint NEXT_PUBLIC_TEMPLATES_URL at
   // templates.<brand> once that standalone catalog UI is stood up.
   templatesUrl: trimSlash(process.env.NEXT_PUBLIC_TEMPLATES_URL ?? `${PLATFORM_URL}/templates`),
-  // The OSS App Store catalog CDN — the live 1000+-app one-click catalog. Fetched
-  // cross-origin from the browser (open CORS), so it needs no BFF (works in the embed).
+  // The OSS App Store catalog — the live 1000+-app one-click catalog.
+  //
+  // THE ONE ENDPOINT THIS APP STILL READS THAT IS NOT api.hanzo.ai. It is a live
+  // cross-origin data API (measured: GET templates.hanzo.ai/meta.json -> 200 499520B
+  // application/json) reachable only because it answers `Access-Control-Allow-Origin: *`
+  // — which is precisely why it never announced itself as a problem: no gate, rate
+  // limit or audit on api.hanzo.ai has ever seen this traffic.
+  //
+  // Moving it needs a cloud-side `/v1/oss/*` head first (measured today: 404). It is a
+  // THREE-file surface, not one endpoint (`@hanzo/ui/oss`) — `<base>/meta.json` is the
+  // catalog, `<base>/blueprints/<id>/<logo>` the icons, `<base>/blueprints/<id>/
+  // docker-compose.yml` the deploy blueprint — so the base moves as a unit and cloud
+  // must serve the whole prefix. Repointing this line before that head exists would
+  // simply break the App Store, so the line stays honest until it can move.
+  //
+  // NB: the destination is NOT `/v1/templates`. That head already exists and is a
+  // DIFFERENT catalog — Hanzo project starters (`{data:[{slug:"synapse",…}]}`, 34948B)
+  // versus self-hostable OSS apps (`[{id:"2fauth",…}]`, 499520B). Folding one onto the
+  // other would collide two unrelated catalogs on one name.
   ossCatalogUrl: trimSlash(process.env.NEXT_PUBLIC_OSS_CATALOG_URL ?? 'https://templates.hanzo.ai'),
   appUrl: trimSlash(process.env.NEXT_PUBLIC_APP_URL ?? 'https://hanzo.app'),
   chatUrl: trimSlash(process.env.NEXT_PUBLIC_CHAT_URL ?? 'https://hanzo.chat'),
 }
 
 /**
- * Cloud `/v1` base — SAME-ORIGIN by default so the session cookie is first-party
- * (cloud.hanzo.ai/v1, no SameSite=None/CORS). The console host's edge route sends
- * /v1 THROUGH the gateway (global IAM-JWT + rate-limit) to the cloud package, so
- * "everything goes through the api.hanzo.ai gateway" holds without the SPA ever
- * leaving its origin. Override with NEXT_PUBLIC_CLOUD_URL for split-origin/dev.
+ * Cloud `/v1` base — `CANONICAL_API_URL`, or `NEXT_PUBLIC_CLOUD_URL` when a
+ * deployment must point elsewhere (local dev against `next dev`, where the Node BFF
+ * and the `next.config.mjs` rewrites are the terminus; or a self-hosted cloud).
+ * That override is BUILD-TIME deploy config — never user input. The user-addable
+ * network `apiEndpoint` (localStorage, see lib/network.ts) is a DIFFERENT and
+ * deliberately weaker knob: it retargets chain/data reads only, never `originV1Url`.
  */
 function cloudUrl(): string {
   const env = process.env.NEXT_PUBLIC_CLOUD_URL
-  if (env) return trimSlash(env)
-  if (typeof window !== 'undefined') return trimSlash(window.location.origin)
-  // SSR/build fallback only (real calls are browser same-origin; the gateway
-  // routes the console host's /v1 to the cloud package). The canonical gated API
-  // host is api.hanzo.ai (== api.cloud.hanzo.ai — the same hanzoai/cloud package).
-  return 'https://api.hanzo.ai'
+  return env ? trimSlash(env) : CANONICAL_API_URL
 }
 
 /**

--- a/src/lib/affiliates/claim.test.ts
+++ b/src/lib/affiliates/claim.test.ts
@@ -8,7 +8,10 @@ import { stashAffiliateCode, attributeAffiliateOnce, __resetAffiliateGuard } fro
  * to `/v1/affiliates/attribute`, plus the localStorage capture + the
  * once-per-session guards.
  */
+// Two hosts, and the split is the point: ORIGIN is where the PAGE is served, API
+// (`CANONICAL_API_URL`) is where every `/v1` call goes. They no longer coincide.
 const ORIGIN = 'https://console.hanzo.ai'
+const API = 'https://api.hanzo.ai'
 
 function memStore() {
   const m = new Map<string, string>()
@@ -70,7 +73,7 @@ describe('affiliate capture + attribute', () => {
     attributeAffiliateOnce('orgB')
     await flush()
     expect(fetched).toHaveLength(1)
-    expect(fetched[0].url).toBe(`${ORIGIN}/v1/affiliates/attribute`)
+    expect(fetched[0].url).toBe(`${API}/v1/affiliates/attribute`)
     expect(fetched[0].method).toBe('POST')
     expect(fetched[0].body).toContain('acme')
     expect(ls.getItem('hz_aff')).toBeNull() // consumed on success

--- a/src/lib/api/admin-affiliates.test.ts
+++ b/src/lib/api/admin-affiliates.test.ts
@@ -3,12 +3,15 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { AdminAffiliatesApi, normalizeAdminAffiliate, normalizeAdminAffiliates } from './admin-affiliates'
 
 /**
- * Admin affiliates API + normalizers. The client hits the console's OWN origin
- * (`<origin>/v1/admin/affiliates…`), which `next.config.mjs` rewrites to the
- * global-admin-gated `app/admin/aggregate` proxy. These tests pin the exact
- * same-origin paths (read + the mutations) and the optional-safe normalizers.
+ * Admin affiliates API + normalizers. The client hits the canonical API host
+ * (`api.hanzo.ai/v1/admin/affiliates…`, `originV1Url` → `config.cloudUrl`) — named,
+ * not inherited from whatever origin serves the page. These tests pin the exact
+ * `/v1/admin/affiliates` paths (read + the mutations) and the optional-safe normalizers.
  */
+// Two hosts, and the split is the point: ORIGIN is where the PAGE is served, API
+// (`CANONICAL_API_URL`) is where every `/v1` call goes. They no longer coincide.
 const ORIGIN = 'https://admin.hanzo.ai'
+const API = 'https://api.hanzo.ai'
 
 describe('Admin affiliates normalizers — envelope-safe', () => {
   it('normalizes the directory + summary', () => {
@@ -35,7 +38,7 @@ describe('Admin affiliates normalizers — envelope-safe', () => {
   })
 })
 
-describe('AdminAffiliatesApi — hits the same-origin admin aggregate paths', () => {
+describe('AdminAffiliatesApi — hits the canonical-API admin aggregate paths', () => {
   const fetched: { url: string; method: string; body: string }[] = []
 
   beforeEach(() => {
@@ -64,15 +67,15 @@ describe('AdminAffiliatesApi — hits the same-origin admin aggregate paths', ()
     delete (globalThis as { window?: unknown }).window
   })
 
-  it('lists via the same-origin admin path (→ app/admin/aggregate rewrite)', async () => {
+  it('lists via the canonical-API admin path', async () => {
     await AdminAffiliatesApi.list()
-    expect(fetched[0].url).toBe(`${ORIGIN}/v1/admin/affiliates`)
+    expect(fetched[0].url).toBe(`${API}/v1/admin/affiliates`)
     expect(fetched[0].method).toBe('GET')
   })
 
   it('approves with an optional code override (POST)', async () => {
     const a = await AdminAffiliatesApi.approve('aff_1', 'acme')
-    expect(fetched[0].url).toBe(`${ORIGIN}/v1/admin/affiliates/aff_1/approve`)
+    expect(fetched[0].url).toBe(`${API}/v1/admin/affiliates/aff_1/approve`)
     expect(fetched[0].method).toBe('POST')
     expect(fetched[0].body).toContain('acme')
     expect(a.code).toBe('acme')
@@ -80,13 +83,13 @@ describe('AdminAffiliatesApi — hits the same-origin admin aggregate paths', ()
 
   it('suspends (POST)', async () => {
     await AdminAffiliatesApi.suspend('aff_1')
-    expect(fetched[0].url).toBe(`${ORIGIN}/v1/admin/affiliates/aff_1/suspend`)
+    expect(fetched[0].url).toBe(`${API}/v1/admin/affiliates/aff_1/suspend`)
     expect(fetched[0].method).toBe('POST')
   })
 
   it('records a payout (POST, amount+method+reference)', async () => {
     await AdminAffiliatesApi.payout('aff_1', { amountCents: 1200, method: 'credits', reference: 'ledger-1' })
-    expect(fetched[0].url).toBe(`${ORIGIN}/v1/admin/affiliates/aff_1/payout`)
+    expect(fetched[0].url).toBe(`${API}/v1/admin/affiliates/aff_1/payout`)
     expect(fetched[0].method).toBe('POST')
     expect(fetched[0].body).toContain('1200')
     expect(fetched[0].body).toContain('credits')
@@ -94,14 +97,14 @@ describe('AdminAffiliatesApi — hits the same-origin admin aggregate paths', ()
 
   it('runs the accrual sweep (POST)', async () => {
     const r = await AdminAffiliatesApi.sweep()
-    expect(fetched[0].url).toBe(`${ORIGIN}/v1/admin/affiliates/sweep`)
+    expect(fetched[0].url).toBe(`${API}/v1/admin/affiliates/sweep`)
     expect(fetched[0].method).toBe('POST')
     expect(r).toEqual({ swept: 3, accrued: 1 })
   })
 
   it('sets the L1 rate (POST, rateBps)', async () => {
     const a = await AdminAffiliatesApi.setRate('aff_1', 2500)
-    expect(fetched[0].url).toBe(`${ORIGIN}/v1/admin/affiliates/aff_1/rate`)
+    expect(fetched[0].url).toBe(`${API}/v1/admin/affiliates/aff_1/rate`)
     expect(fetched[0].method).toBe('POST')
     expect(fetched[0].body).toContain('2500')
     expect(a.id).toBe('aff_1')

--- a/src/lib/api/admin-authors.test.ts
+++ b/src/lib/api/admin-authors.test.ts
@@ -3,12 +3,15 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { AdminAuthorsApi, normalizeAdminAuthor, normalizeAdminAuthors } from './admin-authors'
 
 /**
- * Admin authors API + normalizers. The client hits the console's OWN origin
- * (`<origin>/v1/admin/authors…`), which `next.config.mjs` rewrites to the
- * global-admin-gated `app/admin/aggregate` proxy. These tests pin the exact
- * same-origin paths (read + the mutations) and the optional-safe normalizers.
+ * Admin authors API + normalizers. The client hits the canonical API host
+ * (`api.hanzo.ai/v1/admin/authors…`, `originV1Url` → `config.cloudUrl`) — named, not
+ * inherited from whatever origin serves the page. These tests pin the exact
+ * `/v1/admin/authors` paths (read + the mutations) and the optional-safe normalizers.
  */
+// Two hosts, and the split is the point: ORIGIN is where the PAGE is served, API
+// (`CANONICAL_API_URL`) is where every `/v1` call goes. They no longer coincide.
 const ORIGIN = 'https://admin.hanzo.ai'
+const API = 'https://api.hanzo.ai'
 
 describe('Admin authors normalizers — envelope-safe', () => {
   it('normalizes the directory + summary', () => {
@@ -36,7 +39,7 @@ describe('Admin authors normalizers — envelope-safe', () => {
   })
 })
 
-describe('AdminAuthorsApi — hits the same-origin admin aggregate paths', () => {
+describe('AdminAuthorsApi — hits the canonical-API admin aggregate paths', () => {
   const fetched: { url: string; method: string; body: string }[] = []
 
   beforeEach(() => {
@@ -65,15 +68,15 @@ describe('AdminAuthorsApi — hits the same-origin admin aggregate paths', () =>
     delete (globalThis as { window?: unknown }).window
   })
 
-  it('lists via the same-origin admin path (→ app/admin/aggregate rewrite)', async () => {
+  it('lists via the canonical-API admin path', async () => {
     await AdminAuthorsApi.list()
-    expect(fetched[0].url).toBe(`${ORIGIN}/v1/admin/authors`)
+    expect(fetched[0].url).toBe(`${API}/v1/admin/authors`)
     expect(fetched[0].method).toBe('GET')
   })
 
   it('approves with an optional share override (POST, shareBps)', async () => {
     const a = await AdminAuthorsApi.approve('auth_1', 500)
-    expect(fetched[0].url).toBe(`${ORIGIN}/v1/admin/authors/auth_1/approve`)
+    expect(fetched[0].url).toBe(`${API}/v1/admin/authors/auth_1/approve`)
     expect(fetched[0].method).toBe('POST')
     expect(fetched[0].body).toContain('shareBps')
     expect(fetched[0].body).toContain('500')
@@ -82,20 +85,20 @@ describe('AdminAuthorsApi — hits the same-origin admin aggregate paths', () =>
 
   it('approves with the default share when shareBps is omitted (empty body)', async () => {
     await AdminAuthorsApi.approve('auth_1')
-    expect(fetched[0].url).toBe(`${ORIGIN}/v1/admin/authors/auth_1/approve`)
+    expect(fetched[0].url).toBe(`${API}/v1/admin/authors/auth_1/approve`)
     expect(fetched[0].method).toBe('POST')
     expect(fetched[0].body).not.toContain('shareBps')
   })
 
   it('suspends (POST)', async () => {
     await AdminAuthorsApi.suspend('auth_1')
-    expect(fetched[0].url).toBe(`${ORIGIN}/v1/admin/authors/auth_1/suspend`)
+    expect(fetched[0].url).toBe(`${API}/v1/admin/authors/auth_1/suspend`)
     expect(fetched[0].method).toBe('POST')
   })
 
   it('records a payout (POST, amount+method+reference)', async () => {
     await AdminAuthorsApi.payout('auth_1', { amountCents: 1200, method: 'credits', reference: 'ledger-1' })
-    expect(fetched[0].url).toBe(`${ORIGIN}/v1/admin/authors/auth_1/payout`)
+    expect(fetched[0].url).toBe(`${API}/v1/admin/authors/auth_1/payout`)
     expect(fetched[0].method).toBe('POST')
     expect(fetched[0].body).toContain('1200')
     expect(fetched[0].body).toContain('credits')
@@ -103,7 +106,7 @@ describe('AdminAuthorsApi — hits the same-origin admin aggregate paths', () =>
 
   it('runs the accrual sweep (POST)', async () => {
     const r = await AdminAuthorsApi.sweep()
-    expect(fetched[0].url).toBe(`${ORIGIN}/v1/admin/authors/sweep`)
+    expect(fetched[0].url).toBe(`${API}/v1/admin/authors/sweep`)
     expect(fetched[0].method).toBe('POST')
     expect(r).toEqual({ swept: 3, accrued: 1 })
   })

--- a/src/lib/api/admin-treasury.test.ts
+++ b/src/lib/api/admin-treasury.test.ts
@@ -3,14 +3,17 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { AdminTreasuryApi, normalizeTreasury } from './admin-treasury'
 
 /**
- * Admin treasury API + normalizers. The client hits the console's OWN origin
- * (`<origin>/v1/admin/treasury…`), which `next.config.mjs` rewrites to the
- * global-admin-gated `app/admin/aggregate` proxy. These tests pin the exact
- * same-origin paths (read + the four mutations) and the OPTIONAL-SAFE normalizer:
+ * Admin treasury API + normalizers. The client hits the canonical API host
+ * (`api.hanzo.ai/v1/admin/treasury…`, `originV1Url` → `config.cloudUrl`) — named, not
+ * inherited from whatever origin serves the page. These tests pin the exact
+ * `/v1/admin/treasury` paths (read + the four mutations) and the OPTIONAL-SAFE normalizer:
  * garbage/empty degrades to honest zeros/[]/false (never a fabricated ledger or a
  * faked "anchored" state), and a full valid payload parses correctly.
  */
+// Two hosts, and the split is the point: ORIGIN is where the PAGE is served, API
+// (`CANONICAL_API_URL`) is where every `/v1` call goes. They no longer coincide.
 const ORIGIN = 'https://admin.hanzo.ai'
+const API = 'https://api.hanzo.ai'
 
 describe('normalizeTreasury — optional-safe (honest empties, never fabricated)', () => {
   it('degrades null/garbage to real zeros/[]/false (never throws)', () => {
@@ -131,7 +134,7 @@ describe('normalizeTreasury — optional-safe (honest empties, never fabricated)
   })
 })
 
-describe('AdminTreasuryApi — hits the same-origin admin aggregate paths', () => {
+describe('AdminTreasuryApi — hits the canonical-API admin aggregate paths', () => {
   const fetched: { url: string; method: string; body: string }[] = []
 
   beforeEach(() => {
@@ -161,15 +164,15 @@ describe('AdminTreasuryApi — hits the same-origin admin aggregate paths', () =
     delete (globalThis as { window?: unknown }).window
   })
 
-  it('reads via the same-origin admin path (→ app/admin/aggregate rewrite)', async () => {
+  it('reads via the canonical-API admin path', async () => {
     await AdminTreasuryApi.get()
-    expect(fetched[0].url).toBe(`${ORIGIN}/v1/admin/treasury`)
+    expect(fetched[0].url).toBe(`${API}/v1/admin/treasury`)
     expect(fetched[0].method).toBe('GET')
   })
 
   it('sets the revenue-share policy (POST, revenueShareBps)', async () => {
     const p = await AdminTreasuryApi.setPolicy(750)
-    expect(fetched[0].url).toBe(`${ORIGIN}/v1/admin/treasury/policy`)
+    expect(fetched[0].url).toBe(`${API}/v1/admin/treasury/policy`)
     expect(fetched[0].method).toBe('POST')
     expect(fetched[0].body).toContain('revenueShareBps')
     expect(fetched[0].body).toContain('750')
@@ -178,7 +181,7 @@ describe('AdminTreasuryApi — hits the same-origin admin aggregate paths', () =
 
   it('sweeps revenue-share with an optional period (POST)', async () => {
     const r = await AdminTreasuryApi.sweep(100000, '2026-07')
-    expect(fetched[0].url).toBe(`${ORIGIN}/v1/admin/treasury/sweep`)
+    expect(fetched[0].url).toBe(`${API}/v1/admin/treasury/sweep`)
     expect(fetched[0].method).toBe('POST')
     expect(fetched[0].body).toContain('100000')
     expect(fetched[0].body).toContain('2026-07')
@@ -187,13 +190,13 @@ describe('AdminTreasuryApi — hits the same-origin admin aggregate paths', () =
 
   it('sweeps without a period when none is given (no period key)', async () => {
     await AdminTreasuryApi.sweep(100000)
-    expect(fetched[0].url).toBe(`${ORIGIN}/v1/admin/treasury/sweep`)
+    expect(fetched[0].url).toBe(`${API}/v1/admin/treasury/sweep`)
     expect(fetched[0].body).not.toContain('period')
   })
 
   it('seeds the reserve (POST, amount+memo)', async () => {
     const r = await AdminTreasuryApi.seed(10000, 'Q3 capitalization')
-    expect(fetched[0].url).toBe(`${ORIGIN}/v1/admin/treasury/seed`)
+    expect(fetched[0].url).toBe(`${API}/v1/admin/treasury/seed`)
     expect(fetched[0].method).toBe('POST')
     expect(fetched[0].body).toContain('10000')
     expect(fetched[0].body).toContain('Q3 capitalization')
@@ -203,7 +206,7 @@ describe('AdminTreasuryApi — hits the same-origin admin aggregate paths', () =
 
   it('anchors the current journal root on the Hanzo L1 (POST)', async () => {
     const a = await AdminTreasuryApi.anchor()
-    expect(fetched[0].url).toBe(`${ORIGIN}/v1/admin/treasury/anchor`)
+    expect(fetched[0].url).toBe(`${API}/v1/admin/treasury/anchor`)
     expect(fetched[0].method).toBe('POST')
     expect(a).toMatchObject({ chainId: 36963, status: 'anchored', synced: true, entryCount: 3 })
   })

--- a/src/lib/api/affiliates.test.ts
+++ b/src/lib/api/affiliates.test.ts
@@ -13,13 +13,16 @@ import {
 
 /**
  * Affiliates API + pure normalizers. The client calls the cloud `/v1/affiliates`
- * contract through the console's `/v1` user-bearer proxy (`cloudProxyV1Url` →
- * `<origin>/v1/affiliates` — the live-ingress-safe form for a bearer-scoped
- * head; a bare `/v1/affiliates` 403s on the gateway). These tests pin (1) that each
- * call hits the EXACT `/v1/affiliates…` path, (2) the real store JSON shape
- * normalizes, and (3) a garbage/absent field degrades to a safe default.
+ * contract on the canonical API host (`cloudProxyV1Url` = `originV1Url` →
+ * `api.hanzo.ai/v1/affiliates`) — the host is named, never inherited from whatever
+ * origin serves the page. These tests pin (1) that each call hits the EXACT
+ * `/v1/affiliates…` path, (2) the real store JSON shape normalizes, and (3) a
+ * garbage/absent field degrades to a safe default.
  */
+// Two hosts, and the split is the point: ORIGIN is where the PAGE is served, API
+// (`CANONICAL_API_URL`) is where every `/v1` call goes. They no longer coincide.
 const ORIGIN = 'https://console.hanzo.ai'
+const API = 'https://api.hanzo.ai'
 
 describe('Affiliates normalizers — real cloud JSON shape, defensive', () => {
   it('normalizes the enrolled overview with all fields', () => {
@@ -98,7 +101,7 @@ describe('Affiliates normalizers — real cloud JSON shape, defensive', () => {
   })
 })
 
-describe('AffiliatesApi — hits the /v1/affiliates bearer-proxy path', () => {
+describe('AffiliatesApi — hits the /v1/affiliates path on the canonical API', () => {
   const fetched: { url: string; method: string; body: string }[] = []
 
   beforeEach(() => {
@@ -123,23 +126,23 @@ describe('AffiliatesApi — hits the /v1/affiliates bearer-proxy path', () => {
     delete (globalThis as { window?: unknown }).window
   })
 
-  it('reads the overview via the /v1 bearer BFF (prefix-free /v1, never a /cloud-prefixed or direct cloud-origin call)', async () => {
+  it('reads the overview via GET /v1/affiliates (prefix-free /v1, never a /cloud-prefixed path)', async () => {
     const out = await AffiliatesApi.overview()
-    expect(fetched[0]).toEqual({ url: `${ORIGIN}/v1/affiliates`, method: 'GET', body: '' })
+    expect(fetched[0]).toEqual({ url: `${API}/v1/affiliates`, method: 'GET', body: '' })
     expect(out.code).toBe('acme')
   })
 
-  it('applies with POST through the proxy', async () => {
+  it('applies with POST /v1/affiliates/apply', async () => {
     const r = await AffiliatesApi.apply('acme')
-    expect(fetched[0].url).toBe(`${ORIGIN}/v1/affiliates/apply`)
+    expect(fetched[0].url).toBe(`${API}/v1/affiliates/apply`)
     expect(fetched[0].method).toBe('POST')
     expect(fetched[0].body).toContain('acme')
     expect(r.created).toBe(true)
   })
 
-  it('attributes with POST through the proxy', async () => {
+  it('attributes with POST /v1/affiliates/attribute', async () => {
     const r = await AffiliatesApi.attribute('acme')
-    expect(fetched[0].url).toBe(`${ORIGIN}/v1/affiliates/attribute`)
+    expect(fetched[0].url).toBe(`${API}/v1/affiliates/attribute`)
     expect(fetched[0].method).toBe('POST')
     expect(fetched[0].body).toContain('acme')
     expect(r.created).toBe(true)
@@ -219,32 +222,32 @@ describe('AffiliatesApi dashboard — hits the exact /v1/affiliates paths', () =
 
   it('reads earnings via GET /v1/affiliates/me/earnings', async () => {
     await AffiliatesApi.earnings()
-    expect(fetched[0]).toEqual({ url: `${ORIGIN}/v1/affiliates/me/earnings`, method: 'GET', body: '' })
+    expect(fetched[0]).toEqual({ url: `${API}/v1/affiliates/me/earnings`, method: 'GET', body: '' })
   })
   it('reads links via GET /v1/affiliates/me/links', async () => {
     await AffiliatesApi.links()
-    expect(fetched[0]).toEqual({ url: `${ORIGIN}/v1/affiliates/me/links`, method: 'GET', body: '' })
+    expect(fetched[0]).toEqual({ url: `${API}/v1/affiliates/me/links`, method: 'GET', body: '' })
   })
   it('creates a link via POST /v1/affiliates/me/links', async () => {
     const l = await AffiliatesApi.createLink('twitter')
-    expect(fetched[0].url).toBe(`${ORIGIN}/v1/affiliates/me/links`)
+    expect(fetched[0].url).toBe(`${API}/v1/affiliates/me/links`)
     expect(fetched[0].method).toBe('POST')
     expect(fetched[0].body).toContain('twitter')
     expect(l.code).toBe('xy')
   })
   it('sets the handle via POST /v1/affiliates/me/handle', async () => {
     const h = await AffiliatesApi.setHandle('alice')
-    expect(fetched[0].url).toBe(`${ORIGIN}/v1/affiliates/me/handle`)
+    expect(fetched[0].url).toBe(`${API}/v1/affiliates/me/handle`)
     expect(fetched[0].method).toBe('POST')
     expect(h).toBe('alice')
   })
   it('reads the leaderboard via GET /v1/affiliates/leaderboard', async () => {
     await AffiliatesApi.leaderboard()
-    expect(fetched[0]).toEqual({ url: `${ORIGIN}/v1/affiliates/leaderboard`, method: 'GET', body: '' })
+    expect(fetched[0]).toEqual({ url: `${API}/v1/affiliates/leaderboard`, method: 'GET', body: '' })
   })
   it('pings a click via POST /v1/affiliates/click', async () => {
     await AffiliatesApi.click('xy')
-    expect(fetched[0].url).toBe(`${ORIGIN}/v1/affiliates/click`)
+    expect(fetched[0].url).toBe(`${API}/v1/affiliates/click`)
     expect(fetched[0].method).toBe('POST')
     expect(fetched[0].body).toContain('xy')
   })

--- a/src/lib/api/agents.test.ts
+++ b/src/lib/api/agents.test.ts
@@ -265,7 +265,10 @@ describe('formatters', () => {
  * name path (and URL-encode it), so that regression can't return.
  */
 describe('AgentsApi — single-agent routes are name-keyed', () => {
+  // Two hosts, and the split is the point: ORIGIN is where the PAGE is served, API
+  // (`CANONICAL_API_URL`) is where every `/v1` call goes. They no longer coincide.
   const ORIGIN = 'https://console.hanzo.ai'
+  const API = 'https://api.hanzo.ai'
   let calls: { url: string; method: string }[] = []
 
   beforeEach(() => {
@@ -292,7 +295,7 @@ describe('AgentsApi — single-agent routes are name-keyed', () => {
     await AgentsApi.get('des')
     expect(calls).toHaveLength(1)
     expect(calls[0].method).toBe('GET')
-    expect(calls[0].url).toBe(`${ORIGIN}/v1/agents/des`)
+    expect(calls[0].url).toBe(`${API}/v1/agents/des`)
     // The `agent_…` display id must NEVER be the path segment — that is the 404 bug.
     expect(calls[0].url).not.toContain('agent_')
   })
@@ -301,11 +304,11 @@ describe('AgentsApi — single-agent routes are name-keyed', () => {
     await AgentsApi.remove('des')
     expect(calls).toHaveLength(1)
     expect(calls[0].method).toBe('DELETE')
-    expect(calls[0].url).toBe(`${ORIGIN}/v1/agents/des`)
+    expect(calls[0].url).toBe(`${API}/v1/agents/des`)
   })
 
   it('URL-encodes a name with reserved characters', async () => {
     await AgentsApi.get('a b/c')
-    expect(calls[0].url).toBe(`${ORIGIN}/v1/agents/a%20b%2Fc`)
+    expect(calls[0].url).toBe(`${API}/v1/agents/a%20b%2Fc`)
   })
 })

--- a/src/lib/api/aimetrics.test.ts
+++ b/src/lib/api/aimetrics.test.ts
@@ -277,8 +277,11 @@ describe('recent — newest first, capped', () => {
   })
 })
 
-describe('fetchUsageRecords — through the per-tenant /billing proxy', () => {
+describe('fetchUsageRecords — the per-tenant /v1/billing/usage path', () => {
+  // Two hosts, and the split is the point: ORIGIN is where the PAGE is served, API
+  // (`CANONICAL_API_URL`) is where every `/v1` call goes. They no longer coincide.
   const ORIGIN = 'https://console.hanzo.ai'
+  const API = 'https://api.hanzo.ai'
   const fetched: string[] = []
   beforeEach(() => {
     fetched.length = 0
@@ -296,9 +299,9 @@ describe('fetchUsageRecords — through the per-tenant /billing proxy', () => {
     delete (globalThis as { window?: unknown }).window
   })
 
-  it('hits the same-origin /v1/billing/usage proxy (the /v1-first billing path), never commerce directly', async () => {
+  it('hits /v1/billing/usage on the canonical API (the /v1-first billing path), never commerce directly', async () => {
     const recs = await fetchUsageRecords()
-    expect(fetched[0]).toBe(`${ORIGIN}/v1/billing/usage`)
+    expect(fetched[0]).toBe(`${API}/v1/billing/usage`)
     expect(recs).toHaveLength(1)
     expect(recs[0].model).toBe('gpt-4o-mini')
   })

--- a/src/lib/api/apps.test.ts
+++ b/src/lib/api/apps.test.ts
@@ -11,16 +11,19 @@ import {
 
 /**
  * Apps API (the hanzo.app buildable-sites store) + pure normalizers. The module
- * calls the DOCUMENTED cloud `/v1/projects` contract same-origin, keyless and
- * prefix-free (`originV1Url` → `<origin>/v1/projects`); `next.config.mjs` rewrites
- * that head to the user-bearer `/v1` proxy. These tests pin (1) each call hits
- * the EXACT same-origin `/v1/projects` path (the canonical Agents/CRM form — never a
- * direct cloud-origin call, which 403s), (2) the real projectsvc JSON shape
+ * calls the DOCUMENTED cloud `/v1/projects` contract keyless and prefix-free on the
+ * canonical API host (`originV1Url` → `api.hanzo.ai/v1/projects`) — the host is named,
+ * never inherited from whatever origin serves the page. These tests pin (1) each call
+ * hits the EXACT `/v1/projects` path (the canonical Agents/CRM form — never a
+ * `/cloud`-prefixed one), (2) the real projectsvc JSON shape
  * (projectView/deploymentView) normalizes, (3) a bare array + the flat store-column
  * fallback both read, (4) garbage degrades to a safe default — never throws, and
  * (5) the `hanzo.app/dev?project=<slug>` edit deep-link is built injection-safe.
  */
+// Two hosts, and the split is the point: ORIGIN is where the PAGE is served, API
+// (`CANONICAL_API_URL`) is where every `/v1` call goes. They no longer coincide.
 const ORIGIN = 'https://console.hanzo.ai'
+const API = 'https://api.hanzo.ai'
 
 describe('Apps normalizers — real projectsvc JSON shape, defensive', () => {
   it('normalizes a project view with the nested repo object', () => {
@@ -111,7 +114,7 @@ describe('builderEditUrl — the console→hanzo.app edit deep-link', () => {
   })
 })
 
-describe('AppsApi — hits the same-origin /v1/projects contract (rewritten to the /v1 bearer proxy)', () => {
+describe('AppsApi — hits the /v1/projects contract on the canonical API', () => {
   const fetched: { url: string; method: string }[] = []
 
   beforeEach(() => {
@@ -136,17 +139,17 @@ describe('AppsApi — hits the same-origin /v1/projects contract (rewritten to t
     delete (globalThis as { window?: unknown }).window
   })
 
-  it('lists sites via the same-origin /v1/projects path (not a direct cloud-origin call)', async () => {
+  it('lists sites via the /v1/projects path (never a /cloud-prefixed one)', async () => {
     const out = await AppsApi.list()
-    expect(fetched[0]).toEqual({ url: `${ORIGIN}/v1/projects`, method: 'GET' })
+    expect(fetched[0]).toEqual({ url: `${API}/v1/projects`, method: 'GET' })
     expect(fetched[0].url).not.toContain('/cloud/')
     expect(out.map((a) => a.slug)).toEqual(['landing'])
   })
 
-  it('gets one site by slug and its deployments through the proxy path', async () => {
+  it('gets one site by slug and its deployments on the same /v1/projects path', async () => {
     await AppsApi.get('landing')
     await AppsApi.deployments('landing')
-    expect(fetched[0].url).toBe(`${ORIGIN}/v1/projects/landing`)
-    expect(fetched[1].url).toBe(`${ORIGIN}/v1/projects/landing/deployments`)
+    expect(fetched[0].url).toBe(`${API}/v1/projects/landing`)
+    expect(fetched[1].url).toBe(`${API}/v1/projects/landing/deployments`)
   })
 })

--- a/src/lib/api/audit.test.ts
+++ b/src/lib/api/audit.test.ts
@@ -1,7 +1,10 @@
 import { describe, it, expect, afterEach, vi } from 'vitest'
 import { AuditApi, normalizeEvent } from './audit'
 
+// Two hosts, and the split is the point: ORIGIN is where the PAGE is served, API
+// (`CANONICAL_API_URL`) is where every `/v1` call goes. They no longer coincide.
 const ORIGIN = 'https://console.hanzo.ai'
+const API = 'https://api.hanzo.ai'
 
 function stubJson(body: unknown, status = 200): { url: string } {
   const captured = { url: '' }
@@ -81,6 +84,6 @@ describe('AuditApi.list — org-scoped, filtered, paginated', () => {
   it('page 1 and unfiltered omit the p/ filter params (clean URL)', async () => {
     const cap = stubJson({ status: 'ok', data: [], data2: 0 })
     await AuditApi.list({ page: 1 })
-    expect(cap.url).toBe(`${ORIGIN}/v1/audit`)
+    expect(cap.url).toBe(`${API}/v1/audit`)
   })
 })

--- a/src/lib/api/authors.test.ts
+++ b/src/lib/api/authors.test.ts
@@ -4,13 +4,16 @@ import { AuthorsApi, normalizeOverview, normalizePayout, normalizeRepo, normaliz
 
 /**
  * Authors API + pure normalizers. The client calls the cloud `/v1/authors`
- * contract through the console's `/v1` user-bearer proxy (`cloudProxyV1Url` →
- * `<origin>/v1/authors` — the live-ingress-safe form for a bearer-scoped
- * head; a bare `/v1/authors` 403s on the gateway). These tests pin (1) that each
- * call hits the EXACT `/v1/authors…` path, (2) the real store JSON shape
- * normalizes, and (3) a garbage/absent field degrades to a safe default.
+ * contract on the CANONICAL API host (`cloudProxyV1Url` → `api.hanzo.ai/v1/authors`)
+ * — the host is NAMED, not inherited from wherever the bundle is served. These tests
+ * pin (1) that each call hits the EXACT `/v1/authors…` path on that host, (2) the
+ * real store JSON shape normalizes, and (3) a garbage/absent field degrades to a
+ * safe default.
  */
+/** The PAGE origin — where the console is served from. */
 const ORIGIN = 'https://console.hanzo.ai'
+/** The API host — where it calls, whatever origin it was served from. */
+const API = 'https://api.hanzo.ai'
 
 describe('Authors normalizers — real cloud JSON shape, defensive', () => {
   it('normalizes the enrolled overview with all fields', () => {
@@ -149,15 +152,15 @@ describe('AuthorsApi — hits the /v1/authors bearer-proxy path', () => {
     delete (globalThis as { window?: unknown }).window
   })
 
-  it('reads the overview via the /v1 bearer BFF (prefix-free /v1, never a /cloud-prefixed or direct cloud-origin call)', async () => {
+  it('reads the overview on the canonical API host (prefix-free /v1, never a /cloud-prefixed path)', async () => {
     const out = await AuthorsApi.overview()
-    expect(fetched[0]).toEqual({ url: `${ORIGIN}/v1/authors`, method: 'GET', body: '' })
+    expect(fetched[0]).toEqual({ url: `${API}/v1/authors`, method: 'GET', body: '' })
     expect(out.githubLogin).toBe('octocat')
   })
 
   it('connects with POST through the proxy (githubLogin in body)', async () => {
     const r = await AuthorsApi.connect('octocat')
-    expect(fetched[0].url).toBe(`${ORIGIN}/v1/authors/connect`)
+    expect(fetched[0].url).toBe(`${API}/v1/authors/connect`)
     expect(fetched[0].method).toBe('POST')
     expect(fetched[0].body).toContain('githubLogin')
     expect(fetched[0].body).toContain('octocat')
@@ -166,7 +169,7 @@ describe('AuthorsApi — hits the /v1/authors bearer-proxy path', () => {
 
   it('verifies a repo with POST through the proxy (repoUrl in body)', async () => {
     const r = await AuthorsApi.verifyRepo('https://github.com/octocat/a')
-    expect(fetched[0].url).toBe(`${ORIGIN}/v1/authors/repos/verify`)
+    expect(fetched[0].url).toBe(`${API}/v1/authors/repos/verify`)
     expect(fetched[0].method).toBe('POST')
     expect(fetched[0].body).toContain('repoUrl')
     expect(fetched[0].body).toContain('octocat/a')

--- a/src/lib/api/billing-accounts.test.ts
+++ b/src/lib/api/billing-accounts.test.ts
@@ -2,7 +2,10 @@ import { describe, it, expect, afterEach, vi } from 'vitest'
 
 import { BillingAccountApi, normalizeAccounts, normalizeChain } from './billing-accounts'
 
+/** The PAGE origin — where the console is served from. */
 const ORIGIN = 'https://console.hanzo.ai'
+/** The API host — where it calls, whatever origin it was served from. */
+const API = 'https://api.hanzo.ai'
 
 /** A captured request (url + init) for asserting the exact call the client made. */
 type Captured = { url: string; init: RequestInit }
@@ -148,7 +151,7 @@ describe('bind — the browser names a KIND, never a holder id', () => {
   it('POSTs to the per-tenant billing proxy (the /v1-first filesystem route)', async () => {
     const calls = captureFetch({}, 200)
     await BillingAccountApi.bind({ holderKind: 'org' }, 'acct_x', 0)
-    expect(calls[0].url).toBe(`${ORIGIN}/v1/billing/bindings`)
+    expect(calls[0].url).toBe(`${API}/v1/billing/bindings`)
     expect(calls[0].init.method).toBe('POST')
   })
 
@@ -159,7 +162,7 @@ describe('bind — the browser names a KIND, never a holder id', () => {
     await BillingAccountApi.bind({ holderKind: 'org' }, 'acct_x', 0)
     await BillingAccountApi.bind({ holderKind: 'org' }, 'acct_x', 5)
     expect(calls.map((c) => c.init.method)).toEqual(['POST', 'POST'])
-    expect(calls.map((c) => c.url)).toEqual([`${ORIGIN}/v1/billing/bindings`, `${ORIGIN}/v1/billing/bindings`])
+    expect(calls.map((c) => c.url)).toEqual([`${API}/v1/billing/bindings`, `${API}/v1/billing/bindings`])
     expect(bodyOf(calls[1]).priority).toBe(5)
   })
 })
@@ -169,6 +172,6 @@ describe('unbind', () => {
     const calls = captureFetch(null, 204)
     await BillingAccountApi.unbind('bnd_abc')
     expect(calls[0].init.method).toBe('DELETE')
-    expect(calls[0].url).toBe(`${ORIGIN}/v1/billing/bindings/bnd_abc`)
+    expect(calls[0].url).toBe(`${API}/v1/billing/bindings/bnd_abc`)
   })
 })

--- a/src/lib/api/billing.test.ts
+++ b/src/lib/api/billing.test.ts
@@ -2,7 +2,10 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 
 import { BillingApi, type PaymentMethod, type Subscription } from './billing'
 
+/** The PAGE origin — where the console is served from. */
 const ORIGIN = 'https://console.hanzo.ai'
+/** The API host — where it calls, whatever origin it was served from. */
+const API = 'https://api.hanzo.ai'
 
 /** Stub `window` + a single JSON `fetch` response, shared by the read-only suites. */
 function stubJson(body: unknown, status = 200): void {
@@ -286,21 +289,21 @@ describe('read paths address the canonical short route names', () => {
   it('GETs the saved methods from /v1/billing/methods (never payment-methods)', async () => {
     const calls = captureFetch({ paymentMethods: [] })
     await BillingApi.paymentMethods()
-    expect(calls[0].url).toBe(`${ORIGIN}/v1/billing/methods`)
+    expect(calls[0].url).toBe(`${API}/v1/billing/methods`)
     expect(calls[0].init.method ?? 'GET').toBe('GET')
   })
 
   it('GETs the card-processor config from /v1/billing/settings (never payment-config)', async () => {
     const calls = captureFetch({ provider: 'square', applicationId: 'sq-app', locationId: 'sq-loc', environment: 'production', live: true })
     const cfg = await BillingApi.paymentConfig()
-    expect(calls[0].url).toBe(`${ORIGIN}/v1/billing/settings`)
+    expect(calls[0].url).toBe(`${API}/v1/billing/settings`)
     expect(cfg.applicationId).toBe('sq-app')
   })
 
   it('GETs the spend alerts from /v1/billing/alerts (never spend-alerts)', async () => {
     const calls = captureFetch({ alerts: [] })
     await BillingApi.spendAlerts()
-    expect(calls[0].url).toBe(`${ORIGIN}/v1/billing/alerts`)
+    expect(calls[0].url).toBe(`${API}/v1/billing/alerts`)
   })
 })
 
@@ -317,7 +320,7 @@ describe('BillingApi.createPaymentMethod — saves a Square nonce, never a PAN',
     const m = await BillingApi.createPaymentMethod({ type: 'card', token: 'cnon:card-nonce-ok' })
 
     expect(calls).toHaveLength(1)
-    expect(calls[0].url).toBe(`${ORIGIN}/v1/billing/methods`)
+    expect(calls[0].url).toBe(`${API}/v1/billing/methods`)
     expect(calls[0].init.method).toBe('POST')
     const sent = JSON.parse(calls[0].init.body as string) as Record<string, unknown>
     expect(sent).toEqual({ type: 'card', token: 'cnon:card-nonce-ok' })
@@ -361,7 +364,7 @@ describe('BillingApi.removePaymentMethod — detaches by id (DELETE)', () => {
     const calls = captureFetch({}, 200)
     await BillingApi.removePaymentMethod('pm_1')
     expect(calls).toHaveLength(1)
-    expect(calls[0].url).toBe(`${ORIGIN}/v1/billing/methods/pm_1`)
+    expect(calls[0].url).toBe(`${API}/v1/billing/methods/pm_1`)
     expect(calls[0].init.method).toBe('DELETE')
     expect(calls[0].init.body).toBeUndefined() // a detach carries no body
   })
@@ -369,7 +372,7 @@ describe('BillingApi.removePaymentMethod — detaches by id (DELETE)', () => {
   it('encodes an id with unsafe characters (no path injection)', async () => {
     const calls = captureFetch({}, 204)
     await BillingApi.removePaymentMethod('pm/../secret')
-    expect(calls[0].url).toBe(`${ORIGIN}/v1/billing/methods/pm%2F..%2Fsecret`)
+    expect(calls[0].url).toBe(`${API}/v1/billing/methods/pm%2F..%2Fsecret`)
   })
 })
 
@@ -384,7 +387,7 @@ describe('BillingApi.cancelSubscription — at-period-end vs now', () => {
   it('POSTs {atPeriodEnd:true} to /subscriptions/:id/cancel and reflects the scheduled cancel', async () => {
     const calls = captureFetch({ id: 'sub_1', status: 'active', cancel_at_period_end: true, current_period_end: 1893456000 })
     const s = await BillingApi.cancelSubscription('sub_1', true)
-    expect(calls[0].url).toBe(`${ORIGIN}/v1/billing/subscriptions/sub_1/cancel`)
+    expect(calls[0].url).toBe(`${API}/v1/billing/subscriptions/sub_1/cancel`)
     expect(calls[0].init.method).toBe('POST')
     expect(JSON.parse(calls[0].init.body as string)).toEqual({ atPeriodEnd: true })
     expect(s.cancelAtPeriodEnd).toBe(true)
@@ -405,7 +408,7 @@ describe('BillingApi.reactivateSubscription — clears the scheduled cancel', ()
   it('POSTs to /subscriptions/:id/reactivate and reflects the cleared cancel state', async () => {
     const calls = captureFetch({ id: 'sub_1', status: 'active', cancel_at_period_end: false })
     const s = await BillingApi.reactivateSubscription('sub_1')
-    expect(calls[0].url).toBe(`${ORIGIN}/v1/billing/subscriptions/sub_1/reactivate`)
+    expect(calls[0].url).toBe(`${API}/v1/billing/subscriptions/sub_1/reactivate`)
     expect(calls[0].init.method).toBe('POST')
     expect(s.cancelAtPeriodEnd).toBe(false)
   })

--- a/src/lib/api/canonical-paths.test.ts
+++ b/src/lib/api/canonical-paths.test.ts
@@ -22,7 +22,15 @@ import { PaasApi } from './paas'
 import { CompanyApi } from './company'
 import { CapTableApi } from './captable'
 
+/** The PAGE origin — where the console is served from. */
 const ORIGIN = 'https://console.hanzo.ai'
+/**
+ * The API host — where it calls, whatever origin it was served from. The two are
+ * DELIBERATELY different hosts here: the path contract this file pins is about the
+ * SHAPE after the host (`/v1/<head>`, zero prefix), and naming the host separately is
+ * what proves the shape does not depend on where the bundle happens to be served.
+ */
+const API = 'https://api.hanzo.ai'
 
 let lastUrl = ''
 let lastInit: RequestInit | undefined
@@ -63,55 +71,56 @@ afterEach(() => {
 // the casibase STORE-ADMIN heads (get-stores/…), and machines — all authorize on the
 // Bearer owner claim and reject a cookie-only browser call ("X-Org-Id required" /
 // "valid principal required" / a FALSE "session expired"). So the browser calls the
-// canonical, prefix-free `<origin>/v1/<head>`, which terminates at the console's OWN
-// `app/v1/[...path]` bearer BFF: it mints a short-lived user token from the session and
-// forwards to cloud-api `/v1/*` with the org resolved from the token owner. This block
-// PINS the prefix-free contract so a regression can't re-introduce a `/cloud/` prefix.
-describe('cloud heads → the same-origin /v1 bearer BFF (prefix-free, ZERO /cloud)', () => {
+// canonical, prefix-free `api.hanzo.ai/v1/<head>` — the PKCE bearer travels as a header
+// and cloud resolves the org from its owner claim. The host is NAMED (config.cloudUrl),
+// not inherited from the page origin, so the same bundle addresses the same API from
+// console./admin./billing. or anywhere else it is served. This block PINS the
+// prefix-free contract so a regression can't re-introduce a `/cloud/` prefix.
+describe('cloud heads → the canonical /v1 API host (prefix-free, ZERO /cloud)', () => {
   it('ComputeApi.gpus (inventory) -> /v1/gpus', async () => {
     stub({ gpus: [] })
     await ComputeApi.gpus()
-    expect(lastUrl).toBe(`${ORIGIN}/v1/gpus`)
+    expect(lastUrl).toBe(`${API}/v1/gpus`)
   })
   it('PlatformApi.listClusters -> /v1/clusters', async () => {
     stub({ clusters: [] })
     await PlatformApi.listClusters()
-    expect(lastUrl).toBe(`${ORIGIN}/v1/clusters`)
+    expect(lastUrl).toBe(`${API}/v1/clusters`)
   })
   it('FunctionsApi.list -> /v1/functions', async () => {
     stub({ functions: [] })
     await FunctionsApi.list()
-    expect(lastUrl).toBe(`${ORIGIN}/v1/functions`)
+    expect(lastUrl).toBe(`${API}/v1/functions`)
   })
   it('PaasApi.listProjects -> /v1/platform/projects', async () => {
     stub({ projects: [] })
     await PaasApi.listProjects()
-    expect(lastUrl).toBe(`${ORIGIN}/v1/platform/projects`)
+    expect(lastUrl).toBe(`${API}/v1/platform/projects`)
   })
   it('StorageApi.buckets -> /v1/s3/buckets', async () => {
     stub({ buckets: [] })
     await StorageApi.buckets()
-    expect(lastUrl).toBe(`${ORIGIN}/v1/s3/buckets`)
+    expect(lastUrl).toBe(`${API}/v1/s3/buckets`)
   })
   it('FrameworkApi.doctypes.list -> /v1/framework/doctypes', async () => {
     stub({ data: [] })
     await FrameworkApi.doctypes.list()
-    expect(lastUrl).toBe(`${ORIGIN}/v1/framework/doctypes`)
+    expect(lastUrl).toBe(`${API}/v1/framework/doctypes`)
   })
   it('ProvisioningApi.list(vector) -> /v1/vector', async () => {
     stub([])
     await ProvisioningApi.list('vector')
-    expect(lastUrl).toBe(`${ORIGIN}/v1/vector`)
+    expect(lastUrl).toBe(`${API}/v1/vector`)
   })
   it('ProvisioningApi.list(sql) -> /v1/sql', async () => {
     stub([])
     await ProvisioningApi.list('sql')
-    expect(lastUrl).toBe(`${ORIGIN}/v1/sql`)
+    expect(lastUrl).toBe(`${API}/v1/sql`)
   })
   it('StoreApi.list (embeddings collections) -> /v1/ai/stores', async () => {
     stub({ status: 'ok', msg: '', data: [] })
     await StoreApi.list('acme')
-    expect(lastUrl).toBe(`${ORIGIN}/v1/ai/stores?owner=acme`)
+    expect(lastUrl).toBe(`${API}/v1/ai/stores?owner=acme`)
   })
   it('StoreApi.get -> the member URL, owner and name as SEPARATE segments', async () => {
     stub({ status: 'ok', msg: '', data: {} })
@@ -119,27 +128,27 @@ describe('cloud heads → the same-origin /v1 bearer BFF (prefix-free, ZERO /clo
     // Not `?id=acme/my store`, and not ONE percent-encoded segment: the server
     // decodes %2F back into a separator before routing, so a composite id in a
     // single segment would never match its route.
-    expect(lastUrl).toBe(`${ORIGIN}/v1/ai/stores/acme/my%20store`)
+    expect(lastUrl).toBe(`${API}/v1/ai/stores/acme/my%20store`)
   })
   it('VisorApi.machines -> /v1/machines (bearer-scoped)', async () => {
     stub({ machines: [] })
     await VisorApi.machines()
-    expect(lastUrl).toBe(`${ORIGIN}/v1/machines`)
+    expect(lastUrl).toBe(`${API}/v1/machines`)
   })
   it('CompanyApi.get -> /v1/company (formation state machine)', async () => {
     stub({ formation: { org: 'acme', stage: 'structure' }, nextStages: [] })
     await CompanyApi.get()
-    expect(lastUrl).toBe(`${ORIGIN}/v1/company`)
+    expect(lastUrl).toBe(`${API}/v1/company`)
   })
   it('CapTableApi.summary -> /v1/captable/summary (computed cap table)', async () => {
     stub({ company: { id: 'acme', name: 'Acme' }, totals: {}, byStakeholder: [], byShareClass: [] })
     await CapTableApi.summary()
-    expect(lastUrl).toBe(`${ORIGIN}/v1/captable/summary`)
+    expect(lastUrl).toBe(`${API}/v1/captable/summary`)
   })
   it('CapTableApi.stakeholders.list -> /v1/captable/stakeholders', async () => {
     stub([])
     await CapTableApi.stakeholders.list()
-    expect(lastUrl).toBe(`${ORIGIN}/v1/captable/stakeholders`)
+    expect(lastUrl).toBe(`${API}/v1/captable/stakeholders`)
   })
   it('none of the cloud heads emits a /<svc>/v1/ prefix', async () => {
     const bad = /\/(cloud|vm|ai|billing|org|commerce)\/v1\//
@@ -155,12 +164,12 @@ describe('cloud heads → the same-origin /v1 bearer BFF (prefix-free, ZERO /clo
   })
   // o11y is IAM-gated (403 "no validated principal" for a bearer-less call) and the
   // canonical surface is VERSION-LESS (`/v1/o11y/<resource>`, NO nested v1/v3, NO /api),
-  // so the ApmApi client rides the same-origin `/v1` bearer BFF like the rest — a
-  // logged-in session's minted bearer passes, and the path carries no nested version.
-  it('ApmApi.dashboards -> /v1/o11y/dashboards (version-less, /v1 bearer BFF — NOT /cloud, NOT nested /v1/o11y/v1/...)', async () => {
+  // so the ApmApi client rides the canonical `/v1` host like the rest — the session's
+  // bearer passes, and the path carries no nested version.
+  it('ApmApi.dashboards -> /v1/o11y/dashboards (version-less — NOT /cloud, NOT nested /v1/o11y/v1/...)', async () => {
     stub([])
     await ApmApi.dashboards()
-    expect(lastUrl).toBe(`${ORIGIN}/v1/o11y/dashboards`)
+    expect(lastUrl).toBe(`${API}/v1/o11y/dashboards`)
   })
 })
 
@@ -203,15 +212,15 @@ describe('canonical /v1 — session-scoped data-product clients (no prefix befor
   it('aicatalog fetchPlans -> /v1/plans (AI catalog head -> /ai)', async () => {
     stub({ plans: [] })
     await fetchPlans()
-    expect(lastUrl).toBe(`${ORIGIN}/v1/plans`)
+    expect(lastUrl).toBe(`${API}/v1/plans`)
   })
   it('embeddings EmbeddingsApi.generate -> /v1/embeddings (AI head -> /ai)', async () => {
     stub({})
     await EmbeddingsApi.generate('text-embedding-3-small', 'hi')
-    expect(lastUrl).toBe(`${ORIGIN}/v1/embeddings`)
+    expect(lastUrl).toBe(`${API}/v1/embeddings`)
   })
-  // Functions + PaaS + apm/o11y are NOT bare session clients — they ride the /v1 bearer
-  // BFF (pinned in the "cloud heads → the same-origin /v1 bearer BFF" block above) and
+  // Functions + PaaS + apm/o11y are NOT bare session clients — they are bearer-scoped
+  // (pinned in the "cloud heads → the canonical /v1 API host" block above) and
   // 403 on a cookie-only call. Commerce is NOT a bare-/v1/ client either — it addresses
   // the `/commerce` proxy EXPLICITLY (pinned in the proxy-exceptions block below). The
   // live ingress does not rewrite their heads.
@@ -227,46 +236,45 @@ describe('canonical /v1 — session-scoped data-product clients (no prefix befor
   })
 })
 
-// Money + store + visor-catalog DATA proxies are ALL /v1-first (the /v1-first law): billing
-// + PlansApi (money-truth) ride `/v1/billing/*` (service-token proxy → `app/v1/billing/
-// [...path]`); the store/merchant admin rides `/v1/commerce/*` (→ `app/v1/commerce/[...path]`);
-// the visor compute CATALOG (regions/sizes/accelerators) rides `/v1/vm/*` (→ `app/v1/vm/
-// [...path]`). Each is a FILESYSTEM route MORE SPECIFIC than the `/v1/[...path]` cloud BFF,
-// so it wins without a rewrite. Visor is a DIFFERENT backend — its `/v1/vm/gpus` catalog is
-// DISTINCT from the cloud GPU INVENTORY at `/v1/gpus`; this block PINS each at its own proxy
-// so a regression can't repoint one at a cloud-api `/v1/<head>` that would 404 (wrong backend).
-describe('money + store + visor-catalog proxies (all /v1-first): /v1/billing, /v1/commerce, /v1/vm', () => {
+// Money + store + visor-catalog DATA heads are ALL /v1-first (the /v1-first law): billing
+// + PlansApi (money-truth) ride `/v1/billing/*`; the store/merchant admin rides
+// `/v1/commerce/*`; the visor compute CATALOG (regions/sizes/accelerators) rides
+// `/v1/vm/*`. Each head is namespaced INSIDE `/v1`, never before it. Visor is a DIFFERENT
+// backend — its `/v1/vm/gpus` catalog is DISTINCT from the cloud GPU INVENTORY at
+// `/v1/gpus`; this block PINS each at its own head so a regression can't repoint one at a
+// cloud-api `/v1/<head>` that would 404 (wrong backend).
+describe('money + store + visor-catalog heads (all /v1-first): /v1/billing, /v1/commerce, /v1/vm', () => {
   it('BillingApi.balance -> /v1/billing/balance', async () => {
     stub({ balance: 0, holds: 0, available: 0 })
     await BillingApi.balance()
-    expect(lastUrl).toBe(`${ORIGIN}/v1/billing/balance?currency=usd`)
+    expect(lastUrl).toBe(`${API}/v1/billing/balance?currency=usd`)
   })
 
   it('PlansApi.plans -> /v1/billing/plans (money-truth catalog)', async () => {
     stub([])
     await PlansApi.plans()
-    expect(lastUrl).toBe(`${ORIGIN}/v1/billing/plans`)
+    expect(lastUrl).toBe(`${API}/v1/billing/plans`)
   })
 
   it('CommerceApi.currentStore -> /v1/commerce/store/current', async () => {
     stub({ store: {} })
     await CommerceApi.currentStore()
-    expect(lastUrl).toBe(`${ORIGIN}/v1/commerce/store/current`)
+    expect(lastUrl).toBe(`${API}/v1/commerce/store/current`)
   })
 
   it('VisorApi.gpus (accelerator CATALOG) -> /v1/vm/gpus (visor, NOT cloud-api /v1/gpu-sizes)', async () => {
     stub({ data: [] })
     await VisorApi.gpus()
-    expect(lastUrl).toBe(`${ORIGIN}/v1/vm/gpus`)
+    expect(lastUrl).toBe(`${API}/v1/vm/gpus`)
   })
   it('VisorApi.regions -> /v1/vm/regions', async () => {
     stub({ data: [] })
     await VisorApi.regions()
-    expect(lastUrl).toBe(`${ORIGIN}/v1/vm/regions`)
+    expect(lastUrl).toBe(`${API}/v1/vm/regions`)
   })
   it('VisorApi.sizes -> /v1/vm/sizes', async () => {
     stub({ data: [] })
     await VisorApi.sizes()
-    expect(lastUrl).toBe(`${ORIGIN}/v1/vm/sizes`)
+    expect(lastUrl).toBe(`${API}/v1/vm/sizes`)
   })
 })

--- a/src/lib/api/client.ts
+++ b/src/lib/api/client.ts
@@ -571,11 +571,14 @@ export const cloudProxyV1Url = originV1Url
  *    (clients/account/billing.go — forwards to commerce with the admin service token
  *    SCOPED to the validated caller's own subject); the caller is resolved from the
  *    first-party IAM session cookie (cloud middleware_identity.go).
- *  - Standalone (console2/admin): `/v1/billing/*` resolves to the console's OWN
- *    `app/v1/billing/[...path]` service-token route handler — MORE SPECIFIC than the
- *    `app/v1/[...path]` cloud BFF catch-all, so it wins — which injects the commerce
- *    SERVICE token and pins the caller's OWN billing subject server-side. Tenant
- *    isolation is unchanged; only the PATH is /v1-first (previously namespaced before `/v1/`).
+ *  - Standalone (console2/admin): the SAME cloud bridge. The `app/v1/billing/[...path]`
+ *    service-token handler is not in the production path — `/v1` is edge-routed to
+ *    cloud on every host, so a filesystem route never gets the chance to be "more
+ *    specific" than anything. Measured: `/v1/billing/subscription` answers 404/19B
+ *    identically on console.hanzo.ai, api.hanzo.ai AND admin.hanzo.ai, and
+ *    `/v1/gpu-sizes` · `/v1/regions` · `/v1/sizes` — which exist ONLY as
+ *    `next.config.mjs` rewrites — 404 on admin.hanzo.ai too, which they could not do
+ *    if Next were serving `/v1` there.
  * Absolute on both the server and the browser — `originV1Url` no longer varies with `window`.
  */
 export const billingProxyV1Url = (path: string): string =>
@@ -584,12 +587,16 @@ export const billingProxyV1Url = (path: string): string =>
 /**
  * Build the VISOR catalog path — the canonical `/v1/vm/<path>`
  * (the /v1-first law). The public compute CATALOG (regions / CPU sizes / GPU accelerators)
- * is served by VISOR (`visor.hanzo.svc`), a DISTINCT backend from cloud-api. `/v1/vm/*`
- * resolves to the console's OWN `app/v1/vm/[...path]` user-bearer route handler (MORE
- * SPECIFIC than the `/v1/[...path]` cloud BFF, so it wins), which mints a short-lived
- * user-bound token from the session and forwards to visor (`allowVisorSurface`). Visor's
- * catalog is un-scoped (any signed-in user), so the minted bearer is accepted and the real
- * DO region/size/GPU catalog loads. Absolute on both the server and the browser.
+ * is served by VISOR (`visor.hanzo.svc`), a DISTINCT backend from cloud-api.
+ *
+ * The `app/v1/vm/[...path]` user-bearer handler that used to mint a token and forward to
+ * visor is NOT in the production path: `/v1` is edge-routed to cloud on every host, so a
+ * filesystem route never gets the chance to be "more specific" than anything. This surface
+ * is therefore BROKEN in production today and was before this change — measured,
+ * `/v1/vm/regions` and `/v1/vm/gpus` both answer 404/19B identically on console.hanzo.ai,
+ * api.hanzo.ai AND admin.hanzo.ai, as do the `/v1/regions` · `/v1/sizes` · `/v1/gpu-sizes`
+ * rewrites that feed them. Naming the host does not fix that; cloud needs a `/v1/vm/*`
+ * head (or the visor catalog needs another home). Absolute on server and browser.
  *
  * NB: the visor `/v1/vm/gpus` catalog (accelerator models + VRAM + price) is DISTINCT from
  * the cloud-api GPU INVENTORY at `/v1/gpus` (a per-org shape served by the cloud BFF) — the
@@ -602,16 +609,12 @@ export const vmProxyV1Url = (path: string): string =>
  * Build the COMMERCE store path — the canonical
  * `/v1/commerce/<path>` (the /v1-first law). The store/merchant admin surface
  * (product/order/user/variant/collection/discount/store…) is served by commerce
- * (`commerce.hanzo.svc`) and REQUIRES a Bearer. ONE form for BOTH deployments:
- *  - go:embed console (`IS_EMBED`): same-origin with the cloud binary, which serves
- *    the per-tenant store bridge at `/v1/commerce/<path>` (clients/account/commerce.go),
- *    scoped to the validated caller's own org (first-party IAM session cookie).
- *  - Standalone (console2/admin): `/v1/commerce/*` resolves to the console's OWN
- *    `app/v1/commerce/[...path]` user-bearer route handler (MORE SPECIFIC than the
- *    `app/v1/[...path]` cloud BFF), which mints a short-lived user-bound IAM token and
- *    forwards to commerce with the org resolved from the token owner
- *    (`allowCommerceSurface`). Tenant isolation is unchanged; only the PATH is /v1-first
- *    (previously namespaced before `/v1/`).
+ * (`commerce.hanzo.svc`) and REQUIRES a Bearer. ONE form for BOTH deployments — the cloud binary's per-tenant store bridge at
+ * `/v1/commerce/<path>` (clients/account/commerce.go), scoped to the validated caller's
+ * own org. The `app/v1/commerce/[...path]` user-bearer handler is not in the production
+ * path on either: `/v1` is edge-routed to cloud on every host, so a filesystem route never
+ * gets the chance to be "more specific" than anything. Measured — `/v1/commerce/products`
+ * answers 404/19B identically on console.hanzo.ai, api.hanzo.ai AND admin.hanzo.ai.
  * Absolute on both the server and the browser — `originV1Url` no longer varies with `window`.
  */
 export const commerceProxyV1Url = (path: string): string =>

--- a/src/lib/api/client.ts
+++ b/src/lib/api/client.ts
@@ -11,6 +11,7 @@
  * payload directly or a typed failure — never a half-checked envelope.
  */
 import { activeApiBase } from '~/lib/network'
+import { config } from '~/config'
 import { IS_EMBED } from '~/lib/embed'
 import { currentOrg } from '~/lib/org-scope'
 import { currentActor } from '~/lib/actor-scope'
@@ -345,12 +346,21 @@ export async function postForm<T>(path: string, form: FormData): Promise<T> {
 }
 
 /**
- * Envelope GET pinned to the console's OWN origin (`<origin>/v1/<path>`), so it
- * always hits a same-origin rewrite → hardened server proxy, NEVER the direct-cloud
- * `NEXT_PUBLIC_CLOUD_URL` override. Used by the admin AGGREGATE reads
- * (`/v1/admin/{overview,usage,…}`), which MUST terminate at the global-admin-gated
- * `app/admin/aggregate` proxy — a split-origin cloud URL would bypass that console
- * gate. Same casibase envelope unwrap + `ApiError` as `get`.
+ * Envelope GET on the canonical `/v1/<path>` (`originV1Url`), used by the admin
+ * AGGREGATE reads (`/v1/admin/{overview,usage,…}`).
+ *
+ * These once pinned the page origin so the `next.config.mjs` rewrite would land them
+ * on the global-admin-gated `app/admin/aggregate` proxy. That hop is not in the
+ * production path and has not been for some time: `/v1` is edge-routed to cloud on
+ * every host. Measured — `/v1/gpu-sizes`, `/v1/regions` and `/v1/sizes` exist ONLY as
+ * those rewrites, and all three 404 on admin.hanzo.ai byte-identically to
+ * api.hanzo.ai, which they could not do if Next were serving `/v1` there.
+ *
+ * The gate is therefore cloud's, not the console's, and it holds: `/v1/admin/overview`
+ * answers 403 unauthenticated, and signed-in it returned the SAME 200/539B whether
+ * called same-origin or cross-origin. `originV1Url` still resolves through
+ * `config.cloudUrl` rather than the network-selector base, so a USER-ADDABLE network
+ * still cannot retarget an admin call. Same envelope unwrap + `ApiError` as `get`.
  */
 export async function originGet<T>(path: string, query?: Query): Promise<T> {
   const r = await request<T>('GET', path, { query, absoluteUrl: originV1Url(path) })
@@ -359,14 +369,11 @@ export async function originGet<T>(path: string, query?: Query): Promise<T> {
 }
 
 /**
- * Envelope POST pinned to the console's OWN origin (`<origin>/v1/<path>`) — the
- * mutating twin of `originGet`. The admin AGGREGATE mutations (`/v1/admin/providers/
- * {toggle,primary}`) MUST terminate at the global-admin-gated `app/admin/aggregate`
- * proxy, which applies the same-origin CSRF check, so pinning the ORIGIN (not
- * `config.cloudUrl`) is load-bearing: a split-origin `NEXT_PUBLIC_CLOUD_URL` could
- * otherwise route the write around the console gate. Same casibase envelope unwrap +
- * `ApiError` as `post`; the browser sends its session cookie only — no credential.
- * Optional `headers` ride through for a per-call header (e.g. `Idempotency-Key`).
+ * Envelope POST on the canonical `/v1/<path>` — the mutating twin of `originGet`,
+ * used by the admin AGGREGATE mutations (`/v1/admin/providers/{toggle,primary}`).
+ * See `originGet` for why the old origin pin is not the gate it claimed to be.
+ * Same envelope unwrap + `ApiError` as `post`. Optional `headers` ride through for a
+ * per-call header (e.g. `Idempotency-Key`).
  */
 export async function originPost<T>(path: string, body?: unknown, query?: Query, headers?: Record<string, string>): Promise<T> {
   const r = await request<T>('POST', path, { query, body, absoluteUrl: originV1Url(path), headers })
@@ -375,14 +382,11 @@ export async function originPost<T>(path: string, body?: unknown, query?: Query,
 }
 
 /**
- * Envelope PUT / PATCH / DELETE pinned to the console's OWN origin (`<origin>/v1/<path>`)
- * — the idempotent-upsert / partial-edit / remove twins of `originPost`. Used by the
- * admin AGGREGATE mutations that need a verb beyond POST (`PUT /v1/admin/promos` upserts
- * the single platform promo; `PATCH`/`DELETE /v1/admin/caps/:id` edit/remove a cap).
- * They terminate at the global-admin-gated `app/admin/aggregate` proxy — which applies the
- * same-origin CSRF check on every mutating method (PUT/PATCH/DELETE included) — so pinning
- * the ORIGIN (not `config.cloudUrl`) keeps a split-origin `NEXT_PUBLIC_CLOUD_URL` from
- * routing the write around the console gate. Same casibase envelope unwrap + `ApiError`.
+ * Envelope PUT / PATCH / DELETE on the canonical `/v1/<path>` — the idempotent-upsert /
+ * partial-edit / remove twins of `originPost`. Used by the admin AGGREGATE mutations that
+ * need a verb beyond POST (`PUT /v1/admin/promos` upserts the single platform promo;
+ * `PATCH`/`DELETE /v1/admin/caps/:id` edit/remove a cap). See `originGet` for why the old
+ * origin pin is not the gate it claimed to be. Same envelope unwrap + `ApiError`.
  */
 export async function originPut<T>(path: string, body?: unknown, query?: Query): Promise<T> {
   const r = await request<T>('PUT', path, { query, body, absoluteUrl: originV1Url(path) })
@@ -524,23 +528,31 @@ export const v1Url = (path: string, base: string = activeApiBase()): string =>
   `${base.replace(/\/+$/, '')}/v1/${path.replace(/^\/+/, '')}`
 
 /**
- * The console's OWN same-origin `/v1/<path>` — the ONE client-visible form for EVERY
- * cloud API call, with NO prefix before `/v1/` (CTO contract: zero prefix). The browser
- * calls `<origin>/v1/prompts`; the console's `app/v1/[...path]` catch-all mints a
- * short-lived user bearer from the session and forwards to cloud-api `/v1/*` (org from
- * the Bearer owner) — so the client stays keyless and prefix-free while the bearer trust
- * boundary is unchanged. The NON-cloud heads (AI gateway, admin-aggregate, visor catalog,
- * billing, commerce) are dispatched to their own hardened proxy by a `next.config.mjs`
- * `beforeFiles` rewrite BEFORE the catch-all — invisibly to the client. On the server
- * (SSR / route handlers) there is no `window`, so this yields a root-relative `/v1/<path>`.
+ * The canonical `/v1/<path>` — the ONE client-visible form for EVERY cloud API call,
+ * with NO prefix before `/v1/` (CTO contract: zero prefix). It resolves ABSOLUTE
+ * against `config.cloudUrl` (`api.hanzo.ai`, or `NEXT_PUBLIC_CLOUD_URL` for local dev),
+ * so the host is named rather than inherited from wherever the bundle happens to be
+ * served. Previously this read `window.location.origin` and only *looked* compliant
+ * because console.hanzo.ai and api.hanzo.ai are the same binary — measured identical
+ * (`x-api-version: v1.801.480`, byte-identical bodies) on console/api/admin alike.
+ *
+ * Cross-origin is safe here and was already provisioned for: the credential is the
+ * PKCE bearer from `@hanzo/iam` (a header, origin-independent), every call already
+ * sets `credentials: 'include'`, and api.hanzo.ai answers preflight with
+ * `Access-Control-Allow-Credentials: true` + a reflected `Access-Control-Allow-Origin`
+ * and `Vary: Origin`.
+ *
+ * It reads `config.cloudUrl` and NOT `activeApiBase()` on purpose. `activeApiBase()`
+ * honors the active network's `apiEndpoint`, and a network is USER-ADDABLE and
+ * persisted in localStorage — letting that steer these paths would let a user-added
+ * network redirect the admin-gated surface. Deploy config may move this host; a user
+ * may not. (`v1Url` keeps the network-aware base for chain/data reads.)
  */
-export const originV1Url = (path: string): string => {
-  const clean = path.replace(/^\/+/, '')
-  return typeof window !== 'undefined' ? `${window.location.origin}/v1/${clean}` : `/v1/${clean}`
-}
+export const originV1Url = (path: string): string =>
+  `${config.cloudUrl}/v1/${path.replace(/^\/+/, '')}`
 
 /**
- * Build the console's OWN same-origin `/v1/<path>` for a cloud-api head that must go
+ * Build the canonical `/v1/<path>` for a cloud-api head that must go
  * through the user-bearer BFF. Now IDENTICAL to `originV1Url` — every cloud path is
  * `/v1/`-rooted with ZERO prefix (CTO contract), and the `app/v1/[...path]` catch-all
  * mints a short-lived user bearer from the session and forwards to cloud-api `/v1/*`
@@ -551,7 +563,7 @@ export const originV1Url = (path: string): string => {
 export const cloudProxyV1Url = originV1Url
 
 /**
- * Build the console's OWN same-origin per-tenant billing path — the canonical
+ * Build the per-tenant billing path — the canonical
  * `/v1/billing/<path>` (the /v1-first law: ZERO prefix before `/v1/`). ONE form for
  * BOTH deployments:
  *  - go:embed console (`IS_EMBED`, console.hanzo.ai): same-origin with the cloud
@@ -564,21 +576,20 @@ export const cloudProxyV1Url = originV1Url
  *    `app/v1/[...path]` cloud BFF catch-all, so it wins — which injects the commerce
  *    SERVICE token and pins the caller's OWN billing subject server-side. Tenant
  *    isolation is unchanged; only the PATH is /v1-first (previously namespaced before `/v1/`).
- * On the server (SSR) there is no `window`, so this yields a root-relative `/v1/billing/<path>`.
+ * Absolute on both the server and the browser — `originV1Url` no longer varies with `window`.
  */
 export const billingProxyV1Url = (path: string): string =>
   originV1Url(`billing/${path.replace(/^\/+/, '')}`)
 
 /**
- * Build the console's OWN same-origin VISOR catalog path — the canonical `/v1/vm/<path>`
+ * Build the VISOR catalog path — the canonical `/v1/vm/<path>`
  * (the /v1-first law). The public compute CATALOG (regions / CPU sizes / GPU accelerators)
  * is served by VISOR (`visor.hanzo.svc`), a DISTINCT backend from cloud-api. `/v1/vm/*`
  * resolves to the console's OWN `app/v1/vm/[...path]` user-bearer route handler (MORE
  * SPECIFIC than the `/v1/[...path]` cloud BFF, so it wins), which mints a short-lived
  * user-bound token from the session and forwards to visor (`allowVisorSurface`). Visor's
  * catalog is un-scoped (any signed-in user), so the minted bearer is accepted and the real
- * DO region/size/GPU catalog loads. On the server (SSR) this yields a root-relative
- * `/v1/vm/<path>`.
+ * DO region/size/GPU catalog loads. Absolute on both the server and the browser.
  *
  * NB: the visor `/v1/vm/gpus` catalog (accelerator models + VRAM + price) is DISTINCT from
  * the cloud-api GPU INVENTORY at `/v1/gpus` (a per-org shape served by the cloud BFF) — the
@@ -588,7 +599,7 @@ export const vmProxyV1Url = (path: string): string =>
   originV1Url(`vm/${path.replace(/^\/+/, '')}`)
 
 /**
- * Build the console's OWN same-origin COMMERCE store path — the canonical
+ * Build the COMMERCE store path — the canonical
  * `/v1/commerce/<path>` (the /v1-first law). The store/merchant admin surface
  * (product/order/user/variant/collection/discount/store…) is served by commerce
  * (`commerce.hanzo.svc`) and REQUIRES a Bearer. ONE form for BOTH deployments:
@@ -601,7 +612,7 @@ export const vmProxyV1Url = (path: string): string =>
  *    forwards to commerce with the org resolved from the token owner
  *    (`allowCommerceSurface`). Tenant isolation is unchanged; only the PATH is /v1-first
  *    (previously namespaced before `/v1/`).
- * On the server (SSR) there is no `window`, so this yields a root-relative `/v1/commerce/<path>`.
+ * Absolute on both the server and the browser — `originV1Url` no longer varies with `window`.
  */
 export const commerceProxyV1Url = (path: string): string =>
   originV1Url(`commerce/${path.replace(/^\/+/, '')}`)

--- a/src/lib/api/code.test.ts
+++ b/src/lib/api/code.test.ts
@@ -161,13 +161,16 @@ describe('refs + formatters', () => {
 })
 
 /**
- * The `/v1/code/*` routes are same-origin, prefix-free, and carry NO org param — the
- * console's `app/v1` bearer proxy mints the token and the cloud handler resolves the
- * org from its owner claim (a PHYSICAL per-org SQLite file). These pin that the client
- * builds the right path + query and NEVER leaks an org param client-side.
+ * The `/v1/code/*` routes live on the canonical API host, are prefix-free, and carry NO
+ * org param — the cloud handler resolves the org from the bearer's owner claim (a
+ * PHYSICAL per-org SQLite file). These pin that the client builds the right path + query
+ * and NEVER leaks an org param client-side.
  */
-describe('CodeApi — same-origin, prefix-free, no client-side org', () => {
+describe('CodeApi — canonical API host, prefix-free, no client-side org', () => {
+  /** The PAGE origin — where the console is served from. */
   const ORIGIN = 'https://console.hanzo.ai'
+  /** The API host — where it calls, whatever origin it was served from. */
+  const API = 'https://api.hanzo.ai'
   let calls: { url: string; method: string; body?: string }[] = []
 
   beforeEach(() => {
@@ -195,7 +198,7 @@ describe('CodeApi — same-origin, prefix-free, no client-side org', () => {
     expect(calls).toHaveLength(1)
     expect(calls[0].method).toBe('GET')
     const u = new URL(calls[0].url)
-    expect(u.origin + u.pathname).toBe(`${ORIGIN}/v1/code/search`)
+    expect(u.origin + u.pathname).toBe(`${API}/v1/code/search`)
     expect(u.searchParams.get('q')).toBe('Mount func')
     expect(u.searchParams.get('type')).toBe('symbol')
     expect(u.searchParams.get('limit')).toBe(String(SEARCH_LIMIT))
@@ -215,7 +218,7 @@ describe('CodeApi — same-origin, prefix-free, no client-side org', () => {
   it('ask GETs /v1/code/ask?q (+repo), no org param', async () => {
     await CodeApi.ask('where is auth validated?', 'hanzoai/cloud')
     const u = new URL(calls[0].url)
-    expect(u.origin + u.pathname).toBe(`${ORIGIN}/v1/code/ask`)
+    expect(u.origin + u.pathname).toBe(`${API}/v1/code/ask`)
     expect(u.searchParams.get('q')).toBe('where is auth validated?')
     expect(u.searchParams.get('repo')).toBe('hanzoai/cloud')
     expect(u.searchParams.has('org')).toBe(false)
@@ -224,7 +227,7 @@ describe('CodeApi — same-origin, prefix-free, no client-side org', () => {
   it('context POSTs /v1/code/context with a JSON body', async () => {
     await CodeApi.context('pack this', 'hanzoai/cloud', 4000)
     expect(calls[0].method).toBe('POST')
-    expect(calls[0].url).toBe(`${ORIGIN}/v1/code/context`)
+    expect(calls[0].url).toBe(`${API}/v1/code/context`)
     expect(JSON.parse(calls[0].body ?? '{}')).toMatchObject({ query: 'pack this', repo: 'hanzoai/cloud', budgetTokens: 4000 })
   })
 })

--- a/src/lib/api/crm.test.ts
+++ b/src/lib/api/crm.test.ts
@@ -14,14 +14,16 @@ import {
 
 /**
  * CRM API + pure normalizers. The module calls the DOCUMENTED cloud `/v1/crm`
- * contract same-origin, keyless and prefix-free (`originV1Url` → `<origin>/v1/crm`);
- * `next.config.mjs` rewrites that head to the user-bearer `/v1` proxy. These
- * tests pin (1) that each call hits the EXACT same-origin `/v1/crm` path (the
- * canonical Agents/Evals form — never a direct cloud-origin call, which 403s),
- * (2) that the real store JSON shape (store.go tags) normalizes, (3) list reads any
- * envelope key, and (4) a garbage/absent field degrades to a safe default — never throws.
+ * contract keyless and prefix-free on the canonical API host (`originV1Url` →
+ * `api.hanzo.ai/v1/crm`). These tests pin (1) that each call hits the EXACT `/v1/crm`
+ * path there (the canonical Agents/Evals form), (2) that the real store JSON shape
+ * (store.go tags) normalizes, (3) list reads any envelope key, and (4) a garbage/absent
+ * field degrades to a safe default — never throws.
  */
+/** The PAGE origin — where the console is served from. */
 const ORIGIN = 'https://console.hanzo.ai'
+/** The API host — where it calls, whatever origin it was served from. */
+const API = 'https://api.hanzo.ai'
 
 describe('CRM normalizers — real store.go JSON shape, defensive', () => {
   it('normalizes a company with all fields', () => {
@@ -65,7 +67,7 @@ describe('CRM normalizers — real store.go JSON shape, defensive', () => {
   })
 })
 
-describe('CrmApi — hits the same-origin /v1/crm contract (rewritten to the /v1 bearer proxy)', () => {
+describe('CrmApi — hits the /v1/crm contract on the canonical API host', () => {
   const fetched: { url: string; method: string }[] = []
 
   beforeEach(() => {
@@ -87,27 +89,27 @@ describe('CrmApi — hits the same-origin /v1/crm contract (rewritten to the /v1
     delete (globalThis as { window?: unknown }).window
   })
 
-  it('lists companies via the same-origin /v1/crm path (not a direct cloud-origin call)', async () => {
+  it('lists companies via the prefix-free /v1/crm path', async () => {
     const out = await CrmApi.companies.list()
-    expect(fetched[0]).toEqual({ url: `${ORIGIN}/v1/crm/companies`, method: 'GET' })
+    expect(fetched[0]).toEqual({ url: `${API}/v1/crm/companies`, method: 'GET' })
     expect(out.map((c) => c.name)).toEqual(['Acme'])
   })
 
   it('creates a company with POST through the proxy', async () => {
     await CrmApi.companies.create({ name: 'Acme' })
-    expect(fetched[0]).toEqual({ url: `${ORIGIN}/v1/crm/companies`, method: 'POST' })
+    expect(fetched[0]).toEqual({ url: `${API}/v1/crm/companies`, method: 'POST' })
   })
 
   it('reads the per-org summary', async () => {
     const s = await CrmApi.summary()
-    expect(fetched[0].url).toBe(`${ORIGIN}/v1/crm/summary`)
+    expect(fetched[0].url).toBe(`${API}/v1/crm/summary`)
     expect(s.companies).toBe(1)
   })
 
   it('filters contacts by companyId and lists opportunities by stage', async () => {
     await CrmApi.contacts.list('comp_1')
     await CrmApi.opportunities.list('NEW')
-    expect(fetched[0].url).toBe(`${ORIGIN}/v1/crm/contacts?companyId=comp_1`)
-    expect(fetched[1].url).toBe(`${ORIGIN}/v1/crm/opportunities?stage=NEW`)
+    expect(fetched[0].url).toBe(`${API}/v1/crm/contacts?companyId=comp_1`)
+    expect(fetched[1].url).toBe(`${API}/v1/crm/opportunities?stage=NEW`)
   })
 })

--- a/src/lib/api/csrf.ts
+++ b/src/lib/api/csrf.ts
@@ -22,14 +22,21 @@
 import { IS_EMBED } from '~/lib/embed'
 
 export const CSRF_HEADER = 'X-CSRF-Token'
+import { config } from '~/config'
+
 const MUTATING = new Set(['POST', 'PUT', 'PATCH', 'DELETE'])
 const DEFAULT_TTL_S = 43_200 // 12h — matches the server csrfTTL; only a fallback if expiresIn is absent
 const REFRESH_SKEW_MS = 60_000 // re-mint a minute before the server would reject it
 
 // Same builder as client.ts `originV1Url` (a pure one-liner) — inlined here to keep
 // this module free of an import cycle with client.ts (which imports `applyCsrfToInit`).
-const csrfEndpoint = (): string =>
-  typeof window !== 'undefined' ? `${window.location.origin}/v1/csrf` : '/v1/csrf'
+// It reads `config` directly, which is cycle-free: src/config/index.ts imports nothing.
+//
+// The host MUST match the host the write goes to. A CSRF token is minted and verified
+// against server state, so minting at the page origin while POSTing to api.hanzo.ai
+// would only work for as long as those two happen to be the same binary — which today
+// they are, and which is exactly the coincidence this change stops relying on.
+const csrfEndpoint = (): string => `${config.cloudUrl}/v1/csrf`
 
 let cached: { token: string; expiresAt: number } | null = null
 let inflight: Promise<string | null> | null = null

--- a/src/lib/api/embed-paths.test.ts
+++ b/src/lib/api/embed-paths.test.ts
@@ -1,37 +1,45 @@
 // Embed-mode API path contract. In the go:embed console (IS_EMBED) there is NO Next
 // server, so the service-token BFF route handlers (app/v1/billing, app/v1/commerce,
-// /keys) are stripped by the static export and a request to them falls through to the
-// SPA shell (HTML). The cloud binary serves the SAME heads at the CANONICAL bare /v1/* on
-// the same origin (caller resolved from the first-party IAM session cookie → validated
-// principal), so in embed mode those builders must resolve to bare /v1/*. This pins it;
-// the non-embed contract stays in canonical-paths.test.ts. (cloudProxyV1Url already
-// equals originV1Url on main, so the cloud-head BFF is bare /v1 in every deployment.)
+// /keys) are stripped by the static export and a request to them would fall through to
+// the SPA shell (HTML). The cloud binary serves the SAME heads at the CANONICAL bare
+// /v1/*, so in embed mode those builders must resolve to a bare /v1/<head>/<path> —
+// no proxy namespace before /v1, nothing that needs a Next route handler to exist.
+//
+// The host is NAMED (api.hanzo.ai) rather than inherited from the page origin. That is
+// the deliberate contract change: the embed console used to be correct only BECAUSE it
+// was same-origin with the cloud binary, and a path that misses on that origin lands in
+// the SPA catch-all and answers 200 text/html — a request that reached no backend but
+// looks like a backend error. Naming the host removes that whole failure mode; nothing
+// on api.hanzo.ai can be shadowed by a client-side route. This pins the head shape AND
+// the host; the non-embed contract stays in canonical-paths.test.ts. (cloudProxyV1Url
+// already equals originV1Url on main, so the cloud-head BFF is bare /v1 everywhere.)
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Force embed mode BEFORE importing the builders (IS_EMBED is read at module load).
 vi.mock('~/lib/embed', () => ({ IS_EMBED: true }))
 
-const ORIGIN = typeof window !== 'undefined' ? window.location.origin : ''
+/** The API host — named, so the embed build addresses it from any served origin. */
+const API = 'https://api.hanzo.ai'
 
 describe('embed-mode API paths (IS_EMBED)', () => {
   beforeEach(() => vi.resetModules())
 
   it('billing proxy → bare /v1/billing/<path> (the /v1-first billing path)', async () => {
     const { billingProxyV1Url } = await import('./client')
-    expect(billingProxyV1Url('balance')).toBe(`${ORIGIN}/v1/billing/balance`)
-    expect(billingProxyV1Url('usage')).toBe(`${ORIGIN}/v1/billing/usage`)
-    expect(billingProxyV1Url('invoices')).toBe(`${ORIGIN}/v1/billing/invoices`)
+    expect(billingProxyV1Url('balance')).toBe(`${API}/v1/billing/balance`)
+    expect(billingProxyV1Url('usage')).toBe(`${API}/v1/billing/usage`)
+    expect(billingProxyV1Url('invoices')).toBe(`${API}/v1/billing/invoices`)
   })
 
   it('commerce proxy → bare /v1/commerce/<path>', async () => {
     const { commerceProxyV1Url } = await import('./client')
-    expect(commerceProxyV1Url('product')).toBe(`${ORIGIN}/v1/commerce/product`)
-    expect(commerceProxyV1Url('store/current')).toBe(`${ORIGIN}/v1/commerce/store/current`)
+    expect(commerceProxyV1Url('product')).toBe(`${API}/v1/commerce/product`)
+    expect(commerceProxyV1Url('store/current')).toBe(`${API}/v1/commerce/store/current`)
   })
 
   it('cloud-head BFF is bare /v1 (main collapsed cloudProxyV1Url → originV1Url)', async () => {
     const { cloudProxyV1Url } = await import('./client')
-    expect(cloudProxyV1Url('s3/buckets')).toBe(`${ORIGIN}/v1/s3/buckets`)
+    expect(cloudProxyV1Url('s3/buckets')).toBe(`${API}/v1/s3/buckets`)
     expect(cloudProxyV1Url('framework/doctypes')).not.toContain('/cloud/')
   })
 })

--- a/src/lib/api/finance-ledger.test.ts
+++ b/src/lib/api/finance-ledger.test.ts
@@ -3,19 +3,25 @@ import { describe, it, expect } from 'vitest'
 import { financeUrl, unwrapEnvelope } from './finance-ledger'
 
 /**
- * The console finance transport addresses the `/v1` user-bearer proxy (never a bare
- * `/v1/finance/*`, which 403s cookie-only on the live ingress) and unwraps a casibase
- * envelope. The data contract + normalizers live in the SHARED `@hanzo/finance-ui`
- * package (tested there), so these pin only console's transport wiring.
+ * The console finance transport addresses `/v1/finance/*` on the canonical API host and
+ * unwraps a casibase envelope. The data contract + normalizers live in the SHARED
+ * `@hanzo/finance-ui` package (tested there), so these pin only console's transport wiring.
  */
-describe('financeUrl — /v1 bearer BFF address (SSR, no window)', () => {
-  it('builds the /v1/finance/<head> proxy URL', () => {
-    expect(financeUrl('balance')).toBe('/v1/finance/balance')
-    expect(financeUrl('payment-methods')).toBe('/v1/finance/payment-methods')
+/** The API host — named in config, so the URL never depends on the caller's origin. */
+const API = 'https://api.hanzo.ai'
+
+// There is no `window` in this file — no stub, none needed. That is the point: the
+// address is fully qualified whether it is built in the browser or on the server. It
+// used to degrade to a root-relative `/v1/finance/*` under SSR, which no server-side
+// fetch can resolve.
+describe('financeUrl — the canonical /v1/finance address (window-independent)', () => {
+  it('builds the /v1/finance/<head> URL', () => {
+    expect(financeUrl('balance')).toBe(`${API}/v1/finance/balance`)
+    expect(financeUrl('payment-methods')).toBe(`${API}/v1/finance/payment-methods`)
   })
   it('appends a query, skipping undefined values', () => {
-    expect(financeUrl('usage', { range: '7d' })).toBe('/v1/finance/usage?range=7d')
-    expect(financeUrl('ledger', { range: undefined })).toBe('/v1/finance/ledger')
+    expect(financeUrl('usage', { range: '7d' })).toBe(`${API}/v1/finance/usage?range=7d`)
+    expect(financeUrl('ledger', { range: undefined })).toBe(`${API}/v1/finance/ledger`)
   })
 })
 

--- a/src/lib/api/functions.test.ts
+++ b/src/lib/api/functions.test.ts
@@ -25,13 +25,17 @@ import {
 } from './functions'
 
 /**
- * Functions API + pure logic. The page is wired to the DOCUMENTED same-origin
- * contract (`GET /v1/functions`); these tests pin (1) that the inventory call hits
- * that exact path (not a fabricated endpoint), (2) that both the enriched gateway
- * shape and the raw Fission CRD shape normalize, and (3) that every Overview metric
- * is DERIVED from real rows and degrades to `null` (never invented) when absent.
+ * Functions API + pure logic. The page is wired to the DOCUMENTED contract
+ * (`GET /v1/functions` on the canonical API host); these tests pin (1) that the
+ * inventory call hits that exact path (not a fabricated endpoint), (2) that both the
+ * enriched gateway shape and the raw Fission CRD shape normalize, and (3) that every
+ * Overview metric is DERIVED from real rows and degrades to `null` (never invented)
+ * when absent.
  */
+/** The PAGE origin — where the console is served from. */
 const ORIGIN = 'https://console.hanzo.ai'
+/** The API host — where it calls, whatever origin it was served from. */
+const API = 'https://api.hanzo.ai'
 
 const fn = (over: Partial<ServerlessFunction> = {}): ServerlessFunction => ({
   name: 'fn',
@@ -247,11 +251,11 @@ describe('FunctionsApi.list — hits the documented /v1/functions contract', () 
   it('fetches the inventory at /v1/functions and normalizes it', async () => {
     // The functions surface authorizes on the Bearer owner claim and 403s a cookie-only
     // call ("X-Org-Id required"). So the client calls the canonical, prefix-free
-    // same-origin /v1/functions, which the console's app/v1 bearer BFF serves by minting
-    // a short-lived user token server-side (org resolved from the owner). Same contract as
-    // framework/s3/machines — every cloud path is /v1-rooted, ZERO /cloud prefix.
+    // /v1/functions on the API host, carrying the session's bearer (org resolved from the
+    // owner). Same contract as framework/s3/machines — every cloud path is /v1-rooted,
+    // ZERO /cloud prefix.
     const out = await FunctionsApi.list()
-    expect(fetched).toContain(`${ORIGIN}/v1/functions`)
+    expect(fetched).toContain(`${API}/v1/functions`)
     expect(out.map((f) => f.name)).toEqual(['resize'])
   })
 })

--- a/src/lib/api/guide.test.ts
+++ b/src/lib/api/guide.test.ts
@@ -4,13 +4,16 @@ import { GuideApi, normalizeOverview } from './guide'
 
 /**
  * Guide API + pure normalizers. The module calls the DOCUMENTED cloud `/v1/guide`
- * contract same-origin, keyless and prefix-free (`originV1Url` → `<origin>/v1/guide`);
- * the standalone console rewrites that head to the user-bearer `/v1` proxy, the
- * go:embed console calls cloud directly. These tests pin (1) each call hits the
- * EXACT same-origin `/v1/guide/...` path, (2) the real overview JSON shape (guide.go
- * stepView tags) normalizes, and (3) a garbage/absent field degrades safely.
+ * contract keyless and prefix-free (`originV1Url` → `<api>/v1/guide`), resolved
+ * against the CANONICAL API host — not whatever origin happens to serve the page.
+ * These tests pin (1) each call hits the EXACT `/v1/guide/...` path on that host,
+ * (2) the real overview JSON shape (guide.go stepView tags) normalizes, and (3) a
+ * garbage/absent field degrades safely.
  */
+/** The PAGE origin — where the SPA is served from. */
 const ORIGIN = 'https://console.hanzo.ai'
+/** The canonical API host every `/v1` call resolves against, whatever origin serves the page. */
+const API = 'https://api.hanzo.ai'
 
 describe('Guide normalizers — real guide.go JSON shape, defensive', () => {
   it('normalizes a full overview', () => {
@@ -53,7 +56,7 @@ describe('Guide normalizers — real guide.go JSON shape, defensive', () => {
   })
 })
 
-describe('GuideApi — hits the same-origin /v1/guide contract', () => {
+describe('GuideApi — hits the canonical-API /v1/guide contract', () => {
   const fetched: { url: string; method: string }[] = []
 
   beforeEach(() => {
@@ -78,7 +81,7 @@ describe('GuideApi — hits the same-origin /v1/guide contract', () => {
 
   it('loads the overview from /v1/guide', async () => {
     const o = await GuideApi.overview()
-    expect(fetched[0]).toEqual({ url: `${ORIGIN}/v1/guide`, method: 'GET' })
+    expect(fetched[0]).toEqual({ url: `${API}/v1/guide`, method: 'GET' })
     expect(o.progress.next).toBe('positioning')
   })
 
@@ -88,27 +91,27 @@ describe('GuideApi — hits the same-origin /v1/guide contract', () => {
     await GuideApi.start('email')
     await GuideApi.reset('referral')
     expect(fetched.map((f) => `${f.method} ${f.url}`)).toEqual([
-      `POST ${ORIGIN}/v1/guide/steps/landing/done`,
-      `POST ${ORIGIN}/v1/guide/steps/waitlist/skip`,
-      `POST ${ORIGIN}/v1/guide/steps/email/start`,
-      `POST ${ORIGIN}/v1/guide/steps/referral/reset`,
+      `POST ${API}/v1/guide/steps/landing/done`,
+      `POST ${API}/v1/guide/steps/waitlist/skip`,
+      `POST ${API}/v1/guide/steps/email/start`,
+      `POST ${API}/v1/guide/steps/referral/reset`,
     ])
   })
 
   it('runs "do it for me" (non-streaming) via POST /v1/guide/steps/:id/do', async () => {
     await GuideApi.do('positioning')
-    expect(fetched[0]).toEqual({ url: `${ORIGIN}/v1/guide/steps/positioning/do`, method: 'POST' })
+    expect(fetched[0]).toEqual({ url: `${API}/v1/guide/steps/positioning/do`, method: 'POST' })
   })
 
   it('reads the action ledger from /v1/guide/actions', async () => {
     const acts = await GuideApi.actions()
-    expect(fetched[0].url).toBe(`${ORIGIN}/v1/guide/actions`)
+    expect(fetched[0].url).toBe(`${API}/v1/guide/actions`)
     expect(acts).toHaveLength(1)
     expect(acts[0]).toMatchObject({ id: 'act_1', tool: 'content_generate', ok: true })
   })
 
   it('encodes a step id with special characters', async () => {
     await GuideApi.markDone('a/b')
-    expect(fetched[0].url).toBe(`${ORIGIN}/v1/guide/steps/a%2Fb/done`)
+    expect(fetched[0].url).toBe(`${API}/v1/guide/steps/a%2Fb/done`)
   })
 })

--- a/src/lib/api/iam-paas-embed.test.ts
+++ b/src/lib/api/iam-paas-embed.test.ts
@@ -11,11 +11,19 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
  * platform"). In the embed these MUST address cloud-native `/v1/iam/*` and
  * `/v1/paas/*` (which the cloud binary serves) with the bearer.
  *
+ * The guarded property is the PATH SHAPE — `/v1/`-rooted, never the pruned
+ * `/admin/iam/*` or bare `/paas/*` prefix. The HOST is now named explicitly
+ * (`config.cloudUrl` → api.hanzo.ai) rather than inherited from the page, which is
+ * what made the old outage possible to write in the first place.
+ *
  * IS_EMBED is captured at module load, so it is mocked BEFORE importing the clients.
  */
 vi.mock('~/lib/embed', () => ({ IS_EMBED: true }))
 
+/** The PAGE origin — where the embedded SPA is served from. */
 const ORIGIN = 'https://console.hanzo.ai'
+/** The canonical API host every `/v1` call resolves against, whatever origin serves the page. */
+const API = 'https://api.hanzo.ai'
 
 describe('go:embed IAM-admin + PaaS address cloud-native /v1/* (not the pruned BFF prefixes)', () => {
   const fetched: { url: string; method: string }[] = []
@@ -42,31 +50,31 @@ describe('go:embed IAM-admin + PaaS address cloud-native /v1/* (not the pruned B
     delete (globalThis as { window?: unknown }).window
   })
 
-  it('OrgSwitcher org list → GET <origin>/v1/iam/get-organizations (was /admin/iam → SPA 200)', async () => {
+  it('OrgSwitcher org list → GET <api>/v1/iam/get-organizations (was /admin/iam → SPA 200)', async () => {
     const { IamAdminApi } = await import('./admin')
     await IamAdminApi.organizations()
     expect(fetched).toHaveLength(1)
     expect(fetched[0].method).toBe('GET')
-    expect(fetched[0].url.startsWith(`${ORIGIN}/v1/iam/get-organizations`)).toBe(true)
+    expect(fetched[0].url.startsWith(`${API}/v1/iam/get-organizations`)).toBe(true)
     // The cross-tenant list stays scoped to the reserved admin org (super-admin gate upstream).
     expect(fetched[0].url).toContain('owner=admin')
     // NEVER the pruned BFF prefix that fell through to the SPA index in the embed.
     expect(fetched[0].url).not.toContain('/admin/iam/')
   })
 
-  it('Observe→Status apps inventory → GET <origin>/v1/paas/apps (was /paas/apps → SPA 200)', async () => {
+  it('Observe→Status apps inventory → GET <api>/v1/paas/apps (was /paas/apps → SPA 200)', async () => {
     const { PlatformApi } = await import('./platform')
     await PlatformApi.apps()
     expect(fetched).toHaveLength(1)
     expect(fetched[0].method).toBe('GET')
-    expect(fetched[0].url).toBe(`${ORIGIN}/v1/paas/apps`)
+    expect(fetched[0].url).toBe(`${API}/v1/paas/apps`)
   })
 
   it('an IAM-admin mutation also rides the cloud-native /v1/iam surface', async () => {
     const { IamAdminApi } = await import('./admin')
     await IamAdminApi.approveUser('hanzo/u-1')
     expect(fetched[0].method).toBe('POST')
-    expect(fetched[0].url.startsWith(`${ORIGIN}/v1/iam/approve-user`)).toBe(true)
+    expect(fetched[0].url.startsWith(`${API}/v1/iam/approve-user`)).toBe(true)
     expect(fetched[0].url).not.toContain('/admin/iam/')
   })
 })

--- a/src/lib/api/integrations.test.ts
+++ b/src/lib/api/integrations.test.ts
@@ -13,15 +13,18 @@ import {
 
 /**
  * Integrations API + pure normalizers. The module calls the DOCUMENTED cloud
- * `/v1/integrations` contract same-origin, keyless and prefix-free (`originV1Url` →
- * `<origin>/v1/integrations`); `next.config.mjs` rewrites that head to the user-bearer
- * `/v1` proxy. These tests pin (1) that each call hits the EXACT same-origin
- * `/v1/integrations` path with the right verb (the canonical Agents/CRM form — never a
- * direct cloud-origin call, which 403s), (2) that the real Provider JSON shape (the
- * CONNECTORS_CONTRACT tags) normalizes, (3) the list reads any envelope key, and (4) a
- * garbage/absent field degrades to a safe default — never throws.
+ * `/v1/integrations` contract keyless and prefix-free (`originV1Url` →
+ * `<api>/v1/integrations`), resolved against the CANONICAL API host rather than
+ * whatever origin serves the page. These tests pin (1) that each call hits the EXACT
+ * `/v1/integrations` path on that host with the right verb (the canonical Agents/CRM
+ * form), (2) that the real Provider JSON shape (the CONNECTORS_CONTRACT tags)
+ * normalizes, (3) the list reads any envelope key, and (4) a garbage/absent field
+ * degrades to a safe default — never throws.
  */
+/** The PAGE origin — where the SPA is served from. */
 const ORIGIN = 'https://console.hanzo.ai'
+/** The canonical API host every `/v1` call resolves against, whatever origin serves the page. */
+const API = 'https://api.hanzo.ai'
 
 describe('Integrations normalizers — contract Provider shape, defensive', () => {
   it('normalizes a connected provider with all fields', () => {
@@ -82,7 +85,7 @@ describe('Integrations normalizers — contract Provider shape, defensive', () =
   })
 })
 
-describe('IntegrationsApi — hits the same-origin /v1/integrations contract (rewritten to the /v1 BFF)', () => {
+describe('IntegrationsApi — hits the canonical-API /v1/integrations contract', () => {
   const fetched: { url: string; method: string }[] = []
 
   beforeEach(() => {
@@ -109,27 +112,27 @@ describe('IntegrationsApi — hits the same-origin /v1/integrations contract (re
     delete (globalThis as { window?: unknown }).window
   })
 
-  it('lists providers via GET the same-origin /v1/integrations path (not a direct cloud-origin call)', async () => {
+  it('lists providers via GET the canonical /v1/integrations path', async () => {
     const out = await IntegrationsApi.list()
-    expect(fetched[0]).toEqual({ url: `${ORIGIN}/v1/integrations`, method: 'GET' })
+    expect(fetched[0]).toEqual({ url: `${API}/v1/integrations`, method: 'GET' })
     expect(out.map((p) => p.id)).toEqual(['slack', 'github'])
   })
 
   it('gets one provider by id', async () => {
     const p = await IntegrationsApi.get('slack')
-    expect(fetched[0]).toEqual({ url: `${ORIGIN}/v1/integrations/slack`, method: 'GET' })
+    expect(fetched[0]).toEqual({ url: `${API}/v1/integrations/slack`, method: 'GET' })
     expect(p.id).toBe('slack')
   })
 
   it('connects with POST and returns the authorizeUrl', async () => {
     const { authorizeUrl } = await IntegrationsApi.connect('slack')
-    expect(fetched[0]).toEqual({ url: `${ORIGIN}/v1/integrations/slack/connect`, method: 'POST' })
+    expect(fetched[0]).toEqual({ url: `${API}/v1/integrations/slack/connect`, method: 'POST' })
     expect(authorizeUrl).toBe('https://slack.com/oauth/v2/authorize?x=1')
   })
 
   it('disconnects with POST', async () => {
     await IntegrationsApi.disconnect('slack')
-    expect(fetched[0]).toEqual({ url: `${ORIGIN}/v1/integrations/slack/disconnect`, method: 'POST' })
+    expect(fetched[0]).toEqual({ url: `${API}/v1/integrations/slack/disconnect`, method: 'POST' })
   })
 })
 
@@ -164,7 +167,7 @@ describe('GitHub repo normalizers — defensive, snake_case tolerant', () => {
   })
 })
 
-describe('GitHubApi — hits the same-origin /v1/integrations/github contract', () => {
+describe('GitHubApi — hits the canonical-API /v1/integrations/github contract', () => {
   const fetched: { url: string; method: string; body?: unknown }[] = []
   beforeEach(() => {
     fetched.length = 0
@@ -182,21 +185,21 @@ describe('GitHubApi — hits the same-origin /v1/integrations/github contract', 
     delete (globalThis as { window?: unknown }).window
   })
 
-  it('lists repos via GET the same-origin github/repos path', async () => {
+  it('lists repos via GET the canonical github/repos path', async () => {
     const out = await GitHubApi.listRepos()
-    expect(fetched[0]).toMatchObject({ url: `${ORIGIN}/v1/integrations/github/repos`, method: 'GET' })
+    expect(fetched[0]).toMatchObject({ url: `${API}/v1/integrations/github/repos`, method: 'GET' })
     expect(out.map((r) => r.name)).toEqual(['widgets'])
     expect(out[0].imported).toBe(true)
   })
 
   it('imports selected repos via POST with the {repos} body', async () => {
     const res = await GitHubApi.importRepos({ repos: ['widgets'] })
-    expect(fetched[0]).toMatchObject({ url: `${ORIGIN}/v1/integrations/github/repos/import`, method: 'POST', body: { repos: ['widgets'] } })
+    expect(fetched[0]).toMatchObject({ url: `${API}/v1/integrations/github/repos/import`, method: 'POST', body: { repos: ['widgets'] } })
     expect(res).toEqual({ queued: 1, repos: ['widgets'] })
   })
 
   it('imports all via POST with the {all:true} body', async () => {
     await GitHubApi.importRepos({ all: true })
-    expect(fetched[0]).toMatchObject({ url: `${ORIGIN}/v1/integrations/github/repos/import`, method: 'POST', body: { all: true } })
+    expect(fetched[0]).toMatchObject({ url: `${API}/v1/integrations/github/repos/import`, method: 'POST', body: { all: true } })
   })
 })

--- a/src/lib/api/links.test.ts
+++ b/src/lib/api/links.test.ts
@@ -1,7 +1,10 @@
 import { describe, it, expect, afterEach, vi } from 'vitest'
 import { LinksApi, normalizeLink } from './links'
 
+/** The PAGE origin — where the SPA is served from. */
 const ORIGIN = 'https://console.hanzo.ai'
+/** The canonical API host every `/v1` call resolves against, whatever origin serves the page. */
+const API = 'https://api.hanzo.ai'
 let lastUrl = ''
 let lastInit: RequestInit | undefined
 
@@ -64,7 +67,7 @@ describe('LinksApi transport contract', () => {
       devices: [{ machine: 'm1', host: 'box', accounts: [{ id: 'l1', provider: 'claude' }], activeSessions: 2 }],
     })
     const out = await LinksApi.list()
-    expect(lastUrl).toBe(`${ORIGIN}/v1/links`)
+    expect(lastUrl).toBe(`${API}/v1/links`)
     expect(lastInit?.method ?? 'GET').toBe('GET')
     expect(out.links).toHaveLength(1)
     expect(out.devices[0]?.activeSessions).toBe(2)
@@ -80,7 +83,7 @@ describe('LinksApi transport contract', () => {
       primary: { provider: 'claude', kind: 'subscription', billing: 'plan', available: true, headroomPct: 90, linkId: 'a' },
     })
     const plan = await LinksApi.route()
-    expect(lastUrl).toBe(`${ORIGIN}/v1/links/route`)
+    expect(lastUrl).toBe(`${API}/v1/links/route`)
     expect(plan.candidates).toHaveLength(2)
     expect(plan.primary?.linkId).toBe('a')
     expect(plan.candidates[1]?.billing).toBe('commerce')
@@ -89,14 +92,14 @@ describe('LinksApi transport contract', () => {
   it('revoke(id) DELETEs /v1/links/:id (url-escaped)', async () => {
     stub({ revoked: 1, sessionsStopped: 1 })
     await LinksApi.revoke('link_1')
-    expect(lastUrl).toBe(`${ORIGIN}/v1/links/link_1`)
+    expect(lastUrl).toBe(`${API}/v1/links/link_1`)
     expect(lastInit?.method).toBe('DELETE')
   })
 
   it('revokeDevice(machine) POSTs /v1/links/devices/:machine/revoke and returns the counts', async () => {
     stub({ revoked: 2, sessionsStopped: 3 })
     const r = await LinksApi.revokeDevice('m1')
-    expect(lastUrl).toBe(`${ORIGIN}/v1/links/devices/m1/revoke`)
+    expect(lastUrl).toBe(`${API}/v1/links/devices/m1/revoke`)
     expect(lastInit?.method).toBe('POST')
     expect(r).toEqual({ revoked: 2, sessionsStopped: 3 })
   })

--- a/src/lib/api/model-sync.test.ts
+++ b/src/lib/api/model-sync.test.ts
@@ -2,9 +2,12 @@ import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest'
 
 import { ModelSyncApi } from './model-sync'
 
+/** The PAGE origin — the admin console host the SPA is served from. */
 const ORIGIN = 'https://admin.hanzo.ai'
+/** The canonical API host every `/v1` call resolves against, whatever origin serves the page. */
+const API = 'https://api.hanzo.ai'
 
-describe('ModelSyncApi — same-origin model sync endpoints', () => {
+describe('ModelSyncApi — canonical-API model sync endpoints', () => {
   const calls: { url: string; method: string }[] = []
 
   beforeEach(() => {
@@ -27,17 +30,17 @@ describe('ModelSyncApi — same-origin model sync endpoints', () => {
     delete (globalThis as { window?: unknown }).window
   })
 
-  it('reloadConfig() POSTs same-origin /v1/reload-model-config', async () => {
+  it('reloadConfig() POSTs the canonical /v1/admin/reload-model-config', async () => {
     await ModelSyncApi.reloadConfig()
     expect(calls).toHaveLength(1)
-    expect(calls[0].url).toBe(`${ORIGIN}/v1/admin/reload-model-config`)
+    expect(calls[0].url).toBe(`${API}/v1/admin/reload-model-config`)
     expect(calls[0].method).toBe('POST')
   })
 
-  it('refreshPricing() POSTs same-origin /v1/refresh-model-pricing', async () => {
+  it('refreshPricing() POSTs the canonical /v1/admin/refresh-model-pricing', async () => {
     const res = await ModelSyncApi.refreshPricing()
     expect(calls).toHaveLength(1)
-    expect(calls[0].url).toBe(`${ORIGIN}/v1/admin/refresh-model-pricing`)
+    expect(calls[0].url).toBe(`${API}/v1/admin/refresh-model-pricing`)
     expect(calls[0].method).toBe('POST')
     expect(res.lastPricingRefresh).toBe('2026-07-05T00:00:00.000Z')
   })

--- a/src/lib/api/models-catalog.test.ts
+++ b/src/lib/api/models-catalog.test.ts
@@ -3,16 +3,19 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { CloudModelApi } from './models-catalog'
 
 /**
- * The catalog must reach the model list at the console's OWN same-origin `/v1/models`
- * with NO prefix (the CTO one-endpoint contract). `next.config.mjs` rewrites the
- * `models` head to the `/ai` bearer proxy, which adds the user bearer the gateway
- * requires — so the client stays keyless AND prefix-free, and never makes a
- * cookie-only cross-origin call to the cloud host (the "models missing" bug). We
+ * The catalog must reach the model list at the canonical API host's `/v1/models`
+ * with NO prefix (the CTO one-endpoint contract) — the host is NAMED, not inherited
+ * from whatever origin serves the bundle. The user bearer travels as a header, so the
+ * call is origin-independent; what must never come back is a prefixed head (`/ai/`,
+ * `/cloud/`) or a second data origin (cloud.hanzo.ai — the "models missing" bug). We
  * assert the exact URL the catalog fetches for the model list.
  */
+/** The PAGE origin — where the SPA is served from. */
 const ORIGIN = 'https://console.hanzo.ai'
+/** The canonical API host every `/v1` call resolves against, whatever origin serves the page. */
+const API = 'https://api.hanzo.ai'
 
-describe('CloudModelApi.list — same-origin /v1/models, no prefix', () => {
+describe('CloudModelApi.list — canonical /v1/models, no prefix', () => {
   const fetched: string[] = []
 
   beforeEach(() => {
@@ -34,22 +37,22 @@ describe('CloudModelApi.list — same-origin /v1/models, no prefix', () => {
     delete (globalThis as { window?: unknown }).window
   })
 
-  it('fetches the model list from the same-origin <origin>/v1/models (no /ai, no /cloud prefix)', async () => {
+  it('fetches the model list from the canonical <api>/v1/models (no /ai, no /cloud prefix)', async () => {
     const models = await CloudModelApi.list()
     const modelsUrl = fetched.find((u) => u.endsWith('/models') && !u.includes('pricing'))
-    expect(modelsUrl).toBe(`${ORIGIN}/v1/models`)
+    expect(modelsUrl).toBe(`${API}/v1/models`)
     expect(modelsUrl).not.toContain('/ai/')
     expect(modelsUrl).not.toContain('/cloud/')
     expect(models.map((m) => m.id)).toEqual(['zen-coder'])
     expect(models[0].premium).toBe(true)
   })
 
-  it('never makes a cookie-only cross-origin call to the cloud host for models', async () => {
+  it('never reaches a second data origin for models', async () => {
     await CloudModelApi.list()
-    // The model list must be same-origin (rewritten to the bearer proxy), never a
-    // direct call to the cloud API host (cloud.hanzo.ai) which would be cookie-only.
+    // The model list resolves against the ONE canonical API host — never the legacy
+    // cloud.hanzo.ai head, which would be a second data origin for the same fact.
     const modelsUrl = fetched.find((u) => u.endsWith('/models') && !u.includes('pricing'))
-    expect(modelsUrl?.startsWith(ORIGIN)).toBe(true)
+    expect(modelsUrl?.startsWith(API)).toBe(true)
     expect(modelsUrl).not.toContain('cloud.hanzo.ai')
   })
 })

--- a/src/lib/api/origin-url.test.ts
+++ b/src/lib/api/origin-url.test.ts
@@ -1,44 +1,89 @@
 import { describe, it, expect, afterEach } from 'vitest'
 
+import { CANONICAL_API_URL } from '~/config'
+
 import { originV1Url } from './client'
 
 /**
- * originV1Url is the ONE client-visible form for the AI product surface: same-origin
- * `/v1/<path>` with NO prefix (the CTO one-endpoint contract). next.config rewrites
- * the AI heads to the bearer proxies, so the client never types `/v1` or `/ai`.
+ * originV1Url is the ONE client-visible form for EVERY cloud API call: an ABSOLUTE
+ * `<api-host>/v1/<path>` with NO prefix before `/v1/` (the CTO one-endpoint contract).
+ *
+ * It used to read `window.location.origin`, which only LOOKED compliant because
+ * console.hanzo.ai and api.hanzo.ai are the same binary on the same address —
+ * measured identical (`x-api-version: v1.801.480`, byte-identical bodies). Naming
+ * the host makes the contract true by construction rather than by coincidence, so
+ * the tests below pin the host EXPLICITLY and pin its independence from the page.
  */
 describe('originV1Url', () => {
+  const stubOrigin = (origin: string) => {
+    ;(globalThis as { window?: unknown }).window = { location: { origin } }
+  }
+
   afterEach(() => {
-    // Clean up any window stub between cases.
     delete (globalThis as { window?: unknown }).window
   })
 
-  it('is a same-origin /v1/<path> in the browser (no /cloud, no /ai prefix)', () => {
-    ;(globalThis as { window?: unknown }).window = { location: { origin: 'https://console.hanzo.ai' } }
-    expect(originV1Url('prompts')).toBe('https://console.hanzo.ai/v1/prompts')
-    expect(originV1Url('agents/support-triage')).toBe('https://console.hanzo.ai/v1/agents/support-triage')
-    expect(originV1Url('evals/scores')).toBe('https://console.hanzo.ai/v1/evals/scores')
-    expect(originV1Url('models')).toBe('https://console.hanzo.ai/v1/models')
+  it('is an absolute /v1/<path> on the canonical API host', () => {
+    stubOrigin('https://console.hanzo.ai')
+    expect(originV1Url('prompts')).toBe(`${CANONICAL_API_URL}/v1/prompts`)
+    expect(originV1Url('agents/support-triage')).toBe(`${CANONICAL_API_URL}/v1/agents/support-triage`)
+    expect(originV1Url('evals/scores')).toBe(`${CANONICAL_API_URL}/v1/evals/scores`)
+    expect(originV1Url('models')).toBe(`${CANONICAL_API_URL}/v1/models`)
   })
 
-  it('never contains a /cloud or /ai prefix', () => {
-    ;(globalThis as { window?: unknown }).window = { location: { origin: 'https://console.hanzo.ai' } }
+  it('names api.hanzo.ai — the one endpoint, not a host inherited from the page', () => {
+    stubOrigin('https://console.hanzo.ai')
+    expect(CANONICAL_API_URL).toBe('https://api.hanzo.ai')
+    expect(originV1Url('prompts')).toBe('https://api.hanzo.ai/v1/prompts')
+  })
+
+  /**
+   * THE property the change exists for. Whatever host serves the bundle — the embed
+   * on console.hanzo.ai, the Next server on admin.hanzo.ai, a brand host, or a
+   * relocated deployment — the API host does not move with it.
+   */
+  it('does not vary with the page origin', () => {
+    const hosts = [
+      'https://console.hanzo.ai',
+      'https://admin.hanzo.ai',
+      'https://cloud.lux.cloud',
+      'https://billing.zoo.cloud',
+      'http://localhost:4000',
+    ]
+    for (const h of hosts) {
+      stubOrigin(h)
+      expect(originV1Url('prompts')).toBe(`${CANONICAL_API_URL}/v1/prompts`)
+    }
+  })
+
+  /**
+   * Previously the server branch yielded a ROOT-RELATIVE `/v1/<path>` while the
+   * browser branch yielded an absolute one — the same call producing two shapes
+   * depending on where it ran. Naming the host collapses that: one form, everywhere.
+   */
+  it('is the same on the server as in the browser (no window)', () => {
+    stubOrigin('https://console.hanzo.ai')
+    const inBrowser = originV1Url('prompts')
+    delete (globalThis as { window?: unknown }).window
+    expect(originV1Url('prompts')).toBe(inBrowser)
+    expect(originV1Url('models')).toBe(`${CANONICAL_API_URL}/v1/models`)
+  })
+
+  it('never contains a /cloud, /ai or /api prefix', () => {
+    stubOrigin('https://console.hanzo.ai')
     for (const p of ['prompts', 'agents', 'evals/runs', 'models', 'chat/completions']) {
       const url = originV1Url(p)
       expect(url).not.toContain('/cloud/')
       expect(url).not.toContain('/ai/')
+      expect(url).not.toContain('/api/')
       expect(url).toContain('/v1/')
     }
   })
 
   it('strips a leading slash on the path (no // in the result)', () => {
-    ;(globalThis as { window?: unknown }).window = { location: { origin: 'https://console.hanzo.ai' } }
-    expect(originV1Url('/prompts')).toBe('https://console.hanzo.ai/v1/prompts')
-  })
-
-  it('is root-relative /v1/<path> on the server (no window) — the rewrite still applies', () => {
-    // No window global set.
-    expect(originV1Url('prompts')).toBe('/v1/prompts')
-    expect(originV1Url('models')).toBe('/v1/models')
+    stubOrigin('https://console.hanzo.ai')
+    expect(originV1Url('/prompts')).toBe(`${CANONICAL_API_URL}/v1/prompts`)
+    // No doubled slash anywhere after the scheme.
+    expect(originV1Url('/prompts').replace(/^https?:\/\//, '')).not.toContain('//')
   })
 })

--- a/src/lib/api/plans.test.ts
+++ b/src/lib/api/plans.test.ts
@@ -2,7 +2,10 @@ import { describe, it, expect, afterEach, vi } from 'vitest'
 
 import { PlansApi } from './plans'
 
+/** The PAGE origin — where the SPA is served from. */
 const ORIGIN = 'https://console.hanzo.ai'
+/** The canonical API host every `/v1` call resolves against, whatever origin serves the page. */
+const API = 'https://api.hanzo.ai'
 
 /** A captured request URL for asserting the exact path the client hit. */
 let lastUrl = ''
@@ -57,7 +60,7 @@ describe('PlansApi.plans', () => {
   it('reads the per-tenant billing proxy directly (NOT a bare /v1/pricing or /v1/plans that 401s live)', async () => {
     stubPlans(CATALOG)
     await PlansApi.plans()
-    expect(lastUrl).toBe(`${ORIGIN}/v1/billing/plans`)
+    expect(lastUrl).toBe(`${API}/v1/billing/plans`)
   })
 
   it('maps commerce cents -> whole dollars and carries the Pro tier at $49/mo, popular', async () => {

--- a/src/lib/api/provider-admin.test.ts
+++ b/src/lib/api/provider-admin.test.ts
@@ -5,14 +5,17 @@ import { ProviderAdminApi, deriveHealth, normalizeProvider } from './provider-ad
 /**
  * The provider control board is the platform-wide shared-gateway routing surface
  * (GLOBAL-ADMIN only). Two invariants under test:
- *   1. Its client hits the console's OWN same-origin `/v1/admin/providers` (which
- *      `next.config.mjs` rewrites to the global-admin-gated `/admin/aggregate`
- *      proxy) — NEVER a direct cookie-only call to the cloud host (which would
- *      bypass the console gate), for BOTH the GET list and the POST mutations.
+ *   1. Its client hits the canonical API host's `/v1/admin/providers` — one endpoint,
+ *      zero prefix, for BOTH the GET list and the POST mutations. The host is NAMED
+ *      (`config.cloudUrl`), not inherited from the page: this board is served from
+ *      admin.<brand>, and the API it reads is the same `/v1/admin/*` either way.
  *   2. A provider KEY is never modeled or surfaced — `keyPresent` is a boolean;
  *      even if the backend leaks a raw key field, it never reaches `AdminProvider`.
  */
+/** The PAGE origin — the admin console host this board is served from. */
 const ORIGIN = 'https://admin.hanzo.ai'
+/** The canonical API host every `/v1` call resolves against, whatever origin serves the page. */
+const API = 'https://api.hanzo.ai'
 
 describe('deriveHealth — honest derived verdict (no live probe)', () => {
   it('disabled ⇒ off regardless of key', () => {
@@ -82,7 +85,7 @@ describe('normalizeProvider — optional-safe, key-leak-proof', () => {
   })
 })
 
-describe('ProviderAdminApi — same-origin /v1/admin/providers, never the cloud host', () => {
+describe('ProviderAdminApi — canonical /v1/admin/providers, never a second data origin', () => {
   const calls: { url: string; method: string; body?: string }[] = []
 
   beforeEach(() => {
@@ -105,35 +108,35 @@ describe('ProviderAdminApi — same-origin /v1/admin/providers, never the cloud 
     delete (globalThis as { window?: unknown }).window
   })
 
-  it('list() GETs the same-origin <origin>/v1/admin/providers (no /cloud, no /ai prefix)', async () => {
+  it('list() GETs the canonical <api>/v1/admin/providers (no /cloud, no /ai prefix)', async () => {
     const rows = await ProviderAdminApi.list()
     expect(calls).toHaveLength(1)
-    expect(calls[0].url).toBe(`${ORIGIN}/v1/admin/providers`)
+    expect(calls[0].url).toBe(`${API}/v1/admin/providers`)
     expect(calls[0].method).toBe('GET')
     expect(rows.map((r) => r.name)).toEqual(['do-ai'])
   })
 
-  it('never calls the cloud API host directly (would bypass the console admin gate)', async () => {
+  it('never reaches a second data origin or a prefixed head', async () => {
     await ProviderAdminApi.list()
-    expect(calls[0].url.startsWith(ORIGIN)).toBe(true)
+    expect(calls[0].url.startsWith(API)).toBe(true)
     expect(calls[0].url).not.toContain('cloud.hanzo.ai')
     expect(calls[0].url).not.toContain('/cloud/')
     expect(calls[0].url).not.toContain('/ai/')
   })
 
-  it('toggle() POSTs the {name,enabled} body to same-origin /v1/admin/providers/toggle', async () => {
+  it('toggle() POSTs the {name,enabled} body to the canonical /v1/admin/providers/toggle', async () => {
     const updated = await ProviderAdminApi.toggle('openrouter', false)
     expect(calls).toHaveLength(1)
-    expect(calls[0].url).toBe(`${ORIGIN}/v1/admin/providers/toggle`)
+    expect(calls[0].url).toBe(`${API}/v1/admin/providers/toggle`)
     expect(calls[0].method).toBe('POST')
     expect(JSON.parse(calls[0].body ?? '{}')).toEqual({ name: 'openrouter', enabled: false })
     expect(updated.name).toBe('do-ai')
   })
 
-  it('setPrimary() POSTs {name} to same-origin /v1/admin/providers/primary and returns the list', async () => {
+  it('setPrimary() POSTs {name} to the canonical /v1/admin/providers/primary and returns the list', async () => {
     const rows = await ProviderAdminApi.setPrimary('fireworks')
     expect(calls).toHaveLength(1)
-    expect(calls[0].url).toBe(`${ORIGIN}/v1/admin/providers/primary`)
+    expect(calls[0].url).toBe(`${API}/v1/admin/providers/primary`)
     expect(calls[0].method).toBe('POST')
     expect(JSON.parse(calls[0].body ?? '{}')).toEqual({ name: 'fireworks' })
     expect(rows.map((r) => r.name)).toEqual(['do-ai'])

--- a/src/lib/api/provisioning.test.ts
+++ b/src/lib/api/provisioning.test.ts
@@ -47,14 +47,18 @@ describe('normalizeResourceList', () => {
 })
 
 /**
- * Transport contract — every provisioning call MUST address the console's OWN-origin
- * `/v1` user-bearer proxy (`<origin>/v1/<kind>`), never a bare `/v1/<kind>`.
- * A bare `/v1/*` is routed straight to hanzoai/gateway on the live ingress (no minted
- * Bearer) and 403s "X-Org-Id required", surfacing as a FALSE "Not enabled for your
- * account". These pin the fix so the class-bug can never silently return.
+ * Transport contract — every provisioning call MUST address the canonical API host's
+ * `/v1/<kind>`: ABSOLUTE (the host is named, never inherited from the page origin) and
+ * prefix-free (no `/cloud`, `/vm`, `/ai`, `/billing`, `/commerce` segment before `/v1/`).
+ * A prefixed or mis-hosted head loses the org stamp and 403s "X-Org-Id required",
+ * surfacing as a FALSE "Not enabled for your account". These pin the fix so the
+ * class-bug can never silently return.
  */
-describe('ProvisioningApi transport → /v1 bearer BFF', () => {
+describe('ProvisioningApi transport → canonical /v1', () => {
+  /** The PAGE origin — where the SPA is served from. */
   const ORIGIN = 'https://console.hanzo.ai'
+  /** The canonical API host every `/v1` call resolves against, whatever origin serves the page. */
+  const API = 'https://api.hanzo.ai'
   let lastUrl = ''
 
   beforeEach(() => {
@@ -76,18 +80,18 @@ describe('ProvisioningApi transport → /v1 bearer BFF', () => {
 
   const kinds: ResourceKind[] = ['sql', 'vector', 'datastore', 'kv', 'search', 's3', 'docdb']
 
-  it.each(kinds)('list(%s) hits <origin>/v1/<kind> (prefix-free, ZERO /cloud)', async (kind) => {
+  it.each(kinds)('list(%s) hits <api>/v1/<kind> (prefix-free, ZERO /cloud)', async (kind) => {
     await ProvisioningApi.list(kind)
-    expect(lastUrl).toBe(`${ORIGIN}/v1/${kind}`)
-    expect(lastUrl).not.toMatch(new RegExp(`^${ORIGIN}/(cloud|vm|ai|billing|commerce)/v1/`))
+    expect(lastUrl).toBe(`${API}/v1/${kind}`)
+    expect(lastUrl).not.toMatch(new RegExp(`^${API}/(cloud|vm|ai|billing|commerce)/v1/`))
   })
 
-  it('get/create/remove address the same /v1 bearer BFF', async () => {
+  it('get/create/remove address the same canonical /v1 host', async () => {
     await ProvisioningApi.get('vector', 'gooo')
-    expect(lastUrl).toBe(`${ORIGIN}/v1/vector/gooo`)
+    expect(lastUrl).toBe(`${API}/v1/vector/gooo`)
     await ProvisioningApi.create('vector', 'gooo')
-    expect(lastUrl).toBe(`${ORIGIN}/v1/vector`)
+    expect(lastUrl).toBe(`${API}/v1/vector`)
     await ProvisioningApi.remove('vector', 'gooo')
-    expect(lastUrl).toBe(`${ORIGIN}/v1/vector/gooo`)
+    expect(lastUrl).toBe(`${API}/v1/vector/gooo`)
   })
 })

--- a/src/lib/api/referrals.test.ts
+++ b/src/lib/api/referrals.test.ts
@@ -4,13 +4,17 @@ import { ReferralsApi, normalizeOverview, normalizeMyReferral, normalizeClaim } 
 
 /**
  * Referrals API + pure normalizers. The client calls the cloud `/v1/referrals`
- * contract through the console's `/v1` user-bearer proxy (`cloudProxyV1Url` →
- * `<origin>/v1/referrals` — the live-ingress-safe form for a bearer-scoped
- * head; a bare `/v1/referrals` 403s on the gateway). These tests pin (1) that each
- * call hits the EXACT `/v1/referrals` path, (2) the real store JSON shape
- * normalizes, and (3) a garbage/absent field degrades to a safe default.
+ * contract on the CANONICAL API host (`cloudProxyV1Url` → `originV1Url` →
+ * `config.cloudUrl` = api.hanzo.ai) — the host is NAMED, not inherited from
+ * wherever the bundle is served, so the page origin below is irrelevant to it.
+ * These tests pin (1) that each call hits the EXACT `/v1/referrals` path on that
+ * host, (2) the real store JSON shape normalizes, and (3) a garbage/absent field
+ * degrades to a safe default.
  */
+/** The origin the SPA is served from — deliberately NOT where the API lives. */
 const ORIGIN = 'https://console.hanzo.ai'
+/** The one API host every `/v1` call resolves against (config's CANONICAL_API_URL). */
+const API = 'https://api.hanzo.ai'
 
 describe('Referrals normalizers — real cloud JSON shape, defensive', () => {
   it('normalizes the overview with all fields', () => {
@@ -66,7 +70,7 @@ describe('Referrals normalizers — real cloud JSON shape, defensive', () => {
   })
 })
 
-describe('ReferralsApi — hits the /v1/referrals bearer-proxy path', () => {
+describe('ReferralsApi — hits /v1/referrals on the canonical API host', () => {
   const fetched: { url: string; method: string }[] = []
 
   beforeEach(() => {
@@ -89,15 +93,15 @@ describe('ReferralsApi — hits the /v1/referrals bearer-proxy path', () => {
     delete (globalThis as { window?: unknown }).window
   })
 
-  it('reads the overview via the /v1 bearer BFF (prefix-free /v1, never a /cloud-prefixed or direct cloud-origin call)', async () => {
+  it('reads the overview at /v1/referrals on the canonical API host (prefix-free /v1, never a /cloud-prefixed call)', async () => {
     const out = await ReferralsApi.overview()
-    expect(fetched[0]).toEqual({ url: `${ORIGIN}/v1/referrals`, method: 'GET' })
+    expect(fetched[0]).toEqual({ url: `${API}/v1/referrals`, method: 'GET' })
     expect(out.code).toBe('ABC')
   })
 
-  it('claims a referral with POST through the proxy', async () => {
+  it('claims a referral with POST to the same host', async () => {
     const r = await ReferralsApi.claim('ABC')
-    expect(fetched[0]).toEqual({ url: `${ORIGIN}/v1/referrals/claim`, method: 'POST' })
+    expect(fetched[0]).toEqual({ url: `${API}/v1/referrals/claim`, method: 'POST' })
     expect(r.created).toBe(true)
   })
 })

--- a/src/lib/api/social.test.ts
+++ b/src/lib/api/social.test.ts
@@ -5,13 +5,17 @@ import { SocialApi } from './social'
 /**
  * The console's `/v1/social` BINDING. The contract (types, normalizers, paths) is
  * tested in `@hanzo/ui/product/social` — the ONE place it lives. What is console-only,
- * and therefore tested here, is the TRANSPORT: that a contract path resolves to this
- * origin's `/v1/social/...` (keyless, prefix-free, through the user-bearer BFF), which
- * is the canonical CRM/Agents form.
+ * and therefore tested here, is the TRANSPORT: that a contract path resolves to
+ * `/v1/social/...` on the CANONICAL API host (keyless, prefix-free), which is the
+ * canonical CRM/Agents form. The social product FACE is served from social.hanzo.ai;
+ * its data still comes from the one named API host, never from the face's own origin.
  */
+/** The origin this product face is served from — deliberately NOT where the API lives. */
 const ORIGIN = 'https://social.hanzo.ai'
+/** The one API host every `/v1` call resolves against (config's CANONICAL_API_URL). */
+const API = 'https://api.hanzo.ai'
 
-describe('SocialApi — binds the contract to the console origin', () => {
+describe('SocialApi — binds the contract to the canonical API host', () => {
   const fetched: { url: string; method: string }[] = []
 
   beforeEach(() => {
@@ -36,22 +40,22 @@ describe('SocialApi — binds the contract to the console origin', () => {
     delete (globalThis as { window?: unknown }).window
   })
 
-  it('reads provider readiness via the same-origin /v1/social/providers path', async () => {
+  it('reads provider readiness via the /v1/social/providers path', async () => {
     const caps = await SocialApi.providers()
-    expect(fetched[0]).toEqual({ url: `${ORIGIN}/v1/social/providers`, method: 'GET' })
+    expect(fetched[0]).toEqual({ url: `${API}/v1/social/providers`, method: 'GET' })
     expect(caps[0]).toMatchObject({ provider: 'x', credentialsConfigured: false, missingCredentials: ['X_API_KEY'] })
   })
 
   it('publishes a post with POST /v1/social/posts/:id/publish', async () => {
     const p = await SocialApi.posts.publish('post_1')
-    expect(fetched[0]).toEqual({ url: `${ORIGIN}/v1/social/posts/post_1/publish`, method: 'POST' })
+    expect(fetched[0]).toEqual({ url: `${API}/v1/social/posts/post_1/publish`, method: 'POST' })
     expect(p).toMatchObject({ id: 'post_1', status: 'failed', error: 'provider not configured' })
   })
 
-  it('lists posts and accounts via their same-origin paths', async () => {
+  it('lists posts and accounts via their canonical /v1/social paths', async () => {
     await SocialApi.posts.list()
     await SocialApi.accounts.list('x')
-    expect(fetched[0].url).toBe(`${ORIGIN}/v1/social/posts`)
-    expect(fetched[1].url).toBe(`${ORIGIN}/v1/social/accounts?provider=x`)
+    expect(fetched[0].url).toBe(`${API}/v1/social/posts`)
+    expect(fetched[1].url).toBe(`${API}/v1/social/accounts?provider=x`)
   })
 })

--- a/src/lib/api/storage.test.ts
+++ b/src/lib/api/storage.test.ts
@@ -12,7 +12,10 @@ import {
   uploadTo,
 } from './storage'
 
+/** The origin the SPA is served from — deliberately NOT where the API lives. */
 const ORIGIN = 'https://console.hanzo.ai'
+/** The one API host every `/v1` call resolves against (config's CANONICAL_API_URL). */
+const API = 'https://api.hanzo.ai'
 
 /** Stub window + a single JSON fetch response; capture the URL the client hit. */
 let lastUrl = ''
@@ -118,45 +121,45 @@ describe('storage key helpers', () => {
   })
 })
 
-// ── transport: every call hits the /v1 user-bearer proxy, not the raw cloud ─
+// ── transport: every call hits /v1/s3 on the canonical API host, not the page origin ─
 
-describe('StorageApi transport (same-origin /v1 bearer BFF)', () => {
+describe('StorageApi transport (canonical API host /v1)', () => {
   beforeEach(() => stubJson({ buckets: [] }))
   afterEach(teardown)
 
   it('buckets() GETs /v1/s3/buckets', async () => {
     await StorageApi.buckets()
-    expect(lastUrl).toBe(`${ORIGIN}/v1/s3/buckets`)
+    expect(lastUrl).toBe(`${API}/v1/s3/buckets`)
   })
 
   it('objects() encodes the prefix as a query param', async () => {
     stubJson({ objects: [] })
     await StorageApi.objects('photos', 'a/b/')
-    expect(lastUrl).toBe(`${ORIGIN}/v1/s3/buckets/photos/objects?prefix=a%2Fb%2F`)
+    expect(lastUrl).toBe(`${API}/v1/s3/buckets/photos/objects?prefix=a%2Fb%2F`)
   })
 
   it('objects() with no prefix omits the query', async () => {
     stubJson({ objects: [] })
     await StorageApi.objects('photos')
-    expect(lastUrl).toBe(`${ORIGIN}/v1/s3/buckets/photos/objects`)
+    expect(lastUrl).toBe(`${API}/v1/s3/buckets/photos/objects`)
   })
 
   it('presignDownload() preserves nested key slashes in the path', async () => {
     stubJson({ url: 'https://s3.hanzo.ai/x', method: 'GET' })
     await StorageApi.presignDownload('photos', 'a/b/c.png')
-    expect(lastUrl).toBe(`${ORIGIN}/v1/s3/buckets/photos/objects/a/b/c.png`)
+    expect(lastUrl).toBe(`${API}/v1/s3/buckets/photos/objects/a/b/c.png`)
   })
 
   it('deleteObject() targets the object path (204 resolves)', async () => {
     stubJson(null, 204)
     await StorageApi.deleteObject('photos', 'a/b/c.png')
-    expect(lastUrl).toBe(`${ORIGIN}/v1/s3/buckets/photos/objects/a/b/c.png`)
+    expect(lastUrl).toBe(`${API}/v1/s3/buckets/photos/objects/a/b/c.png`)
   })
 
   it('createBucket() POSTs the name to /v1/s3/buckets', async () => {
     stubJson({ name: 'new-bucket' }, 201)
     const b = await StorageApi.createBucket('new-bucket')
-    expect(lastUrl).toBe(`${ORIGIN}/v1/s3/buckets`)
+    expect(lastUrl).toBe(`${API}/v1/s3/buckets`)
     expect(b?.name).toBe('new-bucket')
   })
 })

--- a/src/lib/api/tasks.ts
+++ b/src/lib/api/tasks.ts
@@ -14,7 +14,7 @@
  * public `tasks.hanzo.ai` TLS is not live yet — the real path is the in-cluster
  * service the proxy targets (TASKS_URL); elsewhere the honest BackendStateCard shows.
  */
-import { restGet } from './client'
+import { restGet, originV1Url } from './client'
 
 /** Cluster liveness — `{ status: "ok" | "down" }`. */
 export type ClusterHealth = { status: string }
@@ -112,11 +112,21 @@ export type ActivityInfo = {
   taskQueue?: string
 }
 
-/** Same-origin `/tasksd` proxy base (server route mints the Bearer + forwards).
- *  NB: the proxy lives at `/tasksd`, NOT `/tasks` — the `tasks` product page owns
- *  the `/tasks/*` SPA routes, so a proxy there would shadow `/tasks/queues` etc. */
-const tasksBase = (): string => (typeof window !== 'undefined' ? `${window.location.origin}/tasksd` : '/tasksd')
-const u = (path: string): string => `${tasksBase()}/${path.replace(/^\/+/, '')}`
+/** `/v1/tasks/<path>` on the canonical API — the surface the retired `/tasksd`
+ *  proxy forwarded to (`TASKS_URL` + `/v1/tasks/*`), now addressed directly.
+ *
+ *  The `/tasksd` spelling existed only to keep a SAME-ORIGIN proxy from shadowing
+ *  the `/tasks/*` SPA routes the tasks product page owns. Addressing api.hanzo.ai
+ *  absolutely removes that collision entirely — a path on the API host cannot
+ *  shadow a client-side route — so the surface gets its real name back.
+ *
+ *  That proxy was a `route.ts`, and `scripts/build-embed.mjs` stashes EVERY route
+ *  handler out of the static export the cloud binary serves, so on console.hanzo.ai
+ *  `/tasksd/*` fell through to the SPA catch-all. Measured before this change:
+ *    GET https://console.hanzo.ai/tasksd/health -> 200 369706B text/html
+ *  and after, against the real surface:
+ *    GET https://api.hanzo.ai/v1/tasks/health   -> 200 33B application/json */
+const u = (path: string): string => originV1Url(`tasks/${path.replace(/^\/+/, '')}`)
 const enc = encodeURIComponent
 
 export const TasksApi = {

--- a/src/lib/api/templates.test.ts
+++ b/src/lib/api/templates.test.ts
@@ -14,6 +14,11 @@ import {
 } from './templates'
 import { ApiError } from './client'
 
+/** The one API host every `/v1` call resolves against (config's CANONICAL_API_URL).
+ *  The page ORIGIN each transport block mocks below is where the SPA is SERVED —
+ *  deliberately NOT where the API lives. */
+const API = 'https://api.hanzo.ai'
+
 const template = (over: Partial<Template> = {}): Template => ({
   slug: 'brainwave',
   title: 'Brainwave',
@@ -174,7 +179,7 @@ describe('normalizeForkedProject', () => {
   })
 })
 
-describe('TemplatesApi.fork — POST /v1/projects/fork (same-origin, no prefix)', () => {
+describe('TemplatesApi.fork — POST /v1/projects/fork (canonical API host, no prefix)', () => {
   const ORIGIN = 'https://console.hanzo.ai'
   let calls: { url: string; method?: string; body?: unknown }[]
 
@@ -198,10 +203,10 @@ describe('TemplatesApi.fork — POST /v1/projects/fork (same-origin, no prefix)'
       )
     })
 
-  it('POSTs {slug} to <origin>/v1/projects/fork and returns the forked project', async () => {
+  it('POSTs {slug} to <api>/v1/projects/fork and returns the forked project', async () => {
     stub(201, { slug: 'brainwave', name: 'Brainwave', framework: 'next', status: 'draft' })
     const p = await TemplatesApi.fork('brainwave')
-    expect(calls[0].url).toBe(`${ORIGIN}/v1/projects/fork`)
+    expect(calls[0].url).toBe(`${API}/v1/projects/fork`)
     expect(calls[0].url).not.toContain('/cloud/')
     expect(calls[0].method).toBe('POST')
     expect(calls[0].body).toEqual({ slug: 'brainwave' })
@@ -250,7 +255,7 @@ describe('isLive', () => {
   })
 })
 
-describe('TemplatesApi.deploy / status — projectsvc deploy (same-origin, no prefix)', () => {
+describe('TemplatesApi.deploy / status — projectsvc deploy (canonical API host, no prefix)', () => {
   const ORIGIN = 'https://console.hanzo.ai'
   let calls: { url: string; method?: string; body?: unknown }[]
 
@@ -274,10 +279,10 @@ describe('TemplatesApi.deploy / status — projectsvc deploy (same-origin, no pr
       )
     })
 
-  it('deploy POSTs {source:git} to <origin>/v1/projects/{slug}/deploy (never /cloud-prefixed)', async () => {
+  it('deploy POSTs {source:git} to <api>/v1/projects/{slug}/deploy (never /cloud-prefixed)', async () => {
     stub(202, { status: 'queued' })
     const r = await TemplatesApi.deploy('brainwave')
-    expect(calls[0].url).toBe(`${ORIGIN}/v1/projects/brainwave/deploy`)
+    expect(calls[0].url).toBe(`${API}/v1/projects/brainwave/deploy`)
     expect(calls[0].url).not.toContain('/cloud/')
     expect(calls[0].method).toBe('POST')
     expect(calls[0].body).toEqual({ source: 'git' })
@@ -287,13 +292,13 @@ describe('TemplatesApi.deploy / status — projectsvc deploy (same-origin, no pr
   it('deploy percent-encodes the slug', async () => {
     stub(202, { status: 'queued' })
     await TemplatesApi.deploy('a/b')
-    expect(calls[0].url).toBe(`${ORIGIN}/v1/projects/a%2Fb/deploy`)
+    expect(calls[0].url).toBe(`${API}/v1/projects/a%2Fb/deploy`)
   })
 
-  it('status GETs <origin>/v1/projects/{slug} and normalizes to a ForkedProject', async () => {
+  it('status GETs <api>/v1/projects/{slug} and normalizes to a ForkedProject', async () => {
     stub(200, { slug: 'brainwave', name: 'Brainwave', framework: 'next', status: 'live', liveUrl: 'https://x' })
     const p = await TemplatesApi.status('brainwave')
-    expect(calls[0].url).toBe(`${ORIGIN}/v1/projects/brainwave`)
+    expect(calls[0].url).toBe(`${API}/v1/projects/brainwave`)
     expect(calls[0].method ?? 'GET').toBe('GET')
     expect(p).toMatchObject({ status: 'live', liveUrl: 'https://x' })
   })

--- a/src/lib/api/train.ts
+++ b/src/lib/api/train.ts
@@ -17,15 +17,26 @@
  * degrades a cell, never the page. Nothing is fabricated: an unreachable/empty
  * endpoint yields an honest empty/backend-state, never demo rows.
  */
-import { restGet, restPost } from './client'
-
-const trainingBase = (): string =>
-  typeof window !== 'undefined' ? `${window.location.origin}/training` : '/training'
+import { restGet, restPost, originV1Url } from './client'
 
 type Query = Record<string, string | number | boolean | undefined | null>
 
 const trainUrl = (path: string, query?: Query): string => {
-  const base = `${trainingBase()}/${path.replace(/^\/+/, '')}`
+  // `/v1/<path>` on the canonical API — the same `/v1/ml/*` + `/v1/finetune/*`
+  // surface the retired `app/training/[...path]` proxy forwarded to (it mapped
+  // `/training/<rel>` → `/v1/<rel>` verbatim), now addressed directly.
+  //
+  // That proxy is a `route.ts`, and `scripts/build-embed.mjs` stashes EVERY route
+  // handler out of the static export the cloud binary serves — so on
+  // console.hanzo.ai `/training/*` matched no handler and fell through to the SPA
+  // catch-all, which answered 200 text/html. `restGet` then threw on parsing HTML
+  // as JSON, and the caller's catch reported a backend error for a request that had
+  // in fact reached no backend at all. Measured before this change:
+  //   GET https://console.hanzo.ai/training/x -> 200 369706B text/html
+  // and after, against the real surface:
+  //   GET https://api.hanzo.ai/v1/ml/models   -> 403 (gated, reached)
+  //   GET https://api.hanzo.ai/v1/finetune/jobs -> 401 (gated, reached)
+  const base = originV1Url(path)
   if (!query) return base
   const qs = new URLSearchParams()
   for (const [k, v] of Object.entries(query)) if (v !== undefined && v !== null && v !== '') qs.set(k, String(v))

--- a/src/lib/api/training.test.ts
+++ b/src/lib/api/training.test.ts
@@ -12,7 +12,10 @@ import {
   normSampleResult,
 } from './training'
 
+/** The origin the SPA is served from — deliberately NOT where the API lives. */
 const ORIGIN = 'https://console.hanzo.ai'
+/** The one API host every `/v1` call resolves against (config's CANONICAL_API_URL). */
+const API = 'https://api.hanzo.ai'
 
 type Call = { url: string; method: string; body: unknown }
 
@@ -108,14 +111,14 @@ describe('training normalizers', () => {
   })
 })
 
-// ── Wire contract (URL + method + body) through the /ai bearer proxy ──────────────────
+// ── Wire contract (URL + method + body) on the canonical API host ─────────────────────
 
 describe('TrainingApi wire contract', () => {
-  it('list() GETs /ai/v1/training/clients and normalizes {clients}', async () => {
+  it('list() GETs /v1/training/clients and normalizes {clients}', async () => {
     const calls = stubFetch(() => ({ body: { clients: [{ id: 'c1', status: 'ready' }, { id: 'c2', status: 'loading' }] } }))
     const out = await TrainingApi.list()
     expect(calls[0].method).toBe('GET')
-    expect(calls[0].url).toBe(ORIGIN + '/v1/training/clients')
+    expect(calls[0].url).toBe(API + '/v1/training/clients')
     expect(out.map((c) => c.id)).toEqual(['c1', 'c2'])
   })
 
@@ -123,7 +126,7 @@ describe('TrainingApi wire contract', () => {
     const calls = stubFetch(() => ({ body: { id: 'c3', base_model: 'HuggingFaceTB/SmolLM2-135M', status: 'loading' } }))
     const out = await TrainingApi.create({ base_model: 'HuggingFaceTB/SmolLM2-135M' })
     expect(calls[0].method).toBe('POST')
-    expect(calls[0].url).toBe(ORIGIN + '/v1/training/clients')
+    expect(calls[0].url).toBe(API + '/v1/training/clients')
     expect(calls[0].body).toEqual({
       base_model: 'HuggingFaceTB/SmolLM2-135M',
       lora_config: { rank: DEFAULT_LORA.rank, alpha: DEFAULT_LORA.alpha, target_modules: [...LLAMA_TARGET_MODULES] },
@@ -142,7 +145,7 @@ describe('TrainingApi wire contract', () => {
     const calls = stubFetch(() => ({ body: { id: 'c1', status: 'ready', loss_history: [2, 1] } }))
     const out = await TrainingApi.get('c1')
     expect(calls[0].method).toBe('GET')
-    expect(calls[0].url).toBe(ORIGIN + '/v1/training/clients/c1')
+    expect(calls[0].url).toBe(API + '/v1/training/clients/c1')
     expect(out.loss_history).toEqual([2, 1])
   })
 
@@ -150,14 +153,14 @@ describe('TrainingApi wire contract', () => {
     const calls = stubFetch(() => ({ body: { id: 'c1', deleted: true } }))
     await TrainingApi.remove('c1')
     expect(calls[0].method).toBe('DELETE')
-    expect(calls[0].url).toBe(ORIGIN + '/v1/training/clients/c1')
+    expect(calls[0].url).toBe(API + '/v1/training/clients/c1')
   })
 
   it('forwardBackward() POSTs {data} and normalizes the result', async () => {
     const calls = stubFetch(() => ({ body: { loss: 1.42, num_tokens: 12, metrics: { grad_norm: 0.5 } } }))
     const out = await TrainingApi.forwardBackward('c1', [{ prompt: 'a', completion: 'b' }])
     expect(calls[0].method).toBe('POST')
-    expect(calls[0].url).toBe(ORIGIN + '/v1/training/clients/c1/forward_backward')
+    expect(calls[0].url).toBe(API + '/v1/training/clients/c1/forward_backward')
     expect(calls[0].body).toEqual({ data: [{ prompt: 'a', completion: 'b' }] })
     expect(out.loss).toBeCloseTo(1.42)
     expect(out.num_tokens).toBe(12)
@@ -166,7 +169,7 @@ describe('TrainingApi wire contract', () => {
   it('optimStep() POSTs {adam_params} and returns the step count', async () => {
     const calls = stubFetch(() => ({ body: { optim_steps: 5 } }))
     const out = await TrainingApi.optimStep('c1', { lr: 1e-4 })
-    expect(calls[0].url).toBe(ORIGIN + '/v1/training/clients/c1/optim_step')
+    expect(calls[0].url).toBe(API + '/v1/training/clients/c1/optim_step')
     expect(calls[0].body).toEqual({ adam_params: { lr: 1e-4 } })
     expect(out.optim_steps).toBe(5)
   })
@@ -174,7 +177,7 @@ describe('TrainingApi wire contract', () => {
   it('sample() POSTs prompt + sampling_params and reads sequences', async () => {
     const calls = stubFetch(() => ({ body: { sequences: [{ tokens: [1], text: ' Paris' }] } }))
     const out = await TrainingApi.sample('c1', { prompt: 'The capital of France is', sampling_params: { max_tokens: 8, temperature: 0.7 }, num_samples: 1 })
-    expect(calls[0].url).toBe(ORIGIN + '/v1/training/clients/c1/sample')
+    expect(calls[0].url).toBe(API + '/v1/training/clients/c1/sample')
     expect(calls[0].body).toEqual({ prompt: 'The capital of France is', sampling_params: { max_tokens: 8, temperature: 0.7 }, num_samples: 1 })
     expect(out.sequences[0].text).toBe(' Paris')
   })
@@ -182,7 +185,7 @@ describe('TrainingApi wire contract', () => {
   it('saveWeights() POSTs {name} and returns {path, format}', async () => {
     const calls = stubFetch(() => ({ body: { path: '/adapters/a1', format: 'peft' } }))
     const out = await TrainingApi.saveWeights('c1', 'a1')
-    expect(calls[0].url).toBe(ORIGIN + '/v1/training/clients/c1/save_weights')
+    expect(calls[0].url).toBe(API + '/v1/training/clients/c1/save_weights')
     expect(calls[0].body).toEqual({ name: 'a1' })
     expect(out).toEqual({ path: '/adapters/a1', format: 'peft' })
   })

--- a/src/lib/api/usage-summary.test.ts
+++ b/src/lib/api/usage-summary.test.ts
@@ -1,7 +1,10 @@
 import { describe, it, expect, afterEach, vi } from 'vitest'
 import { UsageSummaryApi, normalizeSummary } from './usage-summary'
 
+/** The origin the SPA is served from — deliberately NOT where the API lives. */
 const ORIGIN = 'https://console.hanzo.ai'
+/** The one API host every `/v1` call resolves against (config's CANONICAL_API_URL). */
+const API = 'https://api.hanzo.ai'
 
 function stubJson(body: unknown, status = 200): { url: string } {
   const captured = { url: '' }
@@ -61,11 +64,11 @@ describe('normalizeSummary — defensive, never throws', () => {
   })
 })
 
-describe('UsageSummaryApi.summary — same-origin /v1/usage/summary', () => {
-  it('GETs the clean origin URL with the range and decodes the payload', async () => {
+describe('UsageSummaryApi.summary — /v1/usage/summary on the canonical API host', () => {
+  it('GETs the clean canonical URL with the range and decodes the payload', async () => {
     const cap = stubJson({ scope: { org: 'maxpower' }, spend: { available: true, totalCents: 42 }, sources: { commerce: true } })
     const s = await UsageSummaryApi.summary('7d')
-    expect(cap.url).toBe(`${ORIGIN}/v1/usage/summary?range=7d`)
+    expect(cap.url).toBe(`${API}/v1/usage/summary?range=7d`)
     expect(s.org).toBe('maxpower')
     expect(s.spend.totalCents).toBe(42)
   })

--- a/src/lib/entitlements.test.ts
+++ b/src/lib/entitlements.test.ts
@@ -90,12 +90,17 @@ describe('nextEnabled — pure add/remove', () => {
   })
 })
 
+/** The origin the SPA is served from — deliberately NOT where the API lives. */
+const ORIGIN = 'https://console.hanzo.ai'
+/** The one API host every `/v1` call resolves against (config's CANONICAL_API_URL). */
+const API = 'https://api.hanzo.ai'
+
 describe('EntitlementsApi — /v1 client contract (mock until the endpoint lands)', () => {
   const origWindow = (globalThis as { window?: unknown }).window
   let fetchMock: ReturnType<typeof vi.fn>
 
   beforeEach(() => {
-    ;(globalThis as { window?: unknown }).window = { location: { origin: 'https://console.hanzo.ai' } }
+    ;(globalThis as { window?: unknown }).window = { location: { origin: ORIGIN } }
     fetchMock = vi.fn()
     vi.stubGlobal('fetch', fetchMock)
   })
@@ -108,13 +113,13 @@ describe('EntitlementsApi — /v1 client contract (mock until the endpoint lands
   const ok = (body: unknown) =>
     Promise.resolve(new Response(JSON.stringify(body), { status: 200, headers: { 'content-type': 'application/json' } }))
 
-  it('GET hits the /v1 user-bearer proxy at orgs/{org}/entitlements', async () => {
+  it('GET hits /v1/orgs/{org}/entitlements on the canonical API host', async () => {
     fetchMock.mockReturnValue(ok({ enabled: ['agents', 'vector'] }))
     const { EntitlementsApi } = await import('./entitlements')
     const res = await EntitlementsApi.get('maxpower')
     expect(res.enabled).toEqual(['agents', 'vector'])
     const calledUrl = String(fetchMock.mock.calls[0][0])
-    expect(calledUrl).toBe('https://console.hanzo.ai/v1/orgs/maxpower/entitlements')
+    expect(calledUrl).toBe(`${API}/v1/orgs/maxpower/entitlements`)
   })
 
   it('normalizes a garbage payload to an honest empty enabled list', async () => {
@@ -129,7 +134,7 @@ describe('EntitlementsApi — /v1 client contract (mock until the endpoint lands
     const res = await EntitlementsApi.update('maxpower', { add: ['agents'] })
     expect(res.enabled).toEqual(['agents'])
     const [calledUrl, init] = fetchMock.mock.calls[0]
-    expect(String(calledUrl)).toBe('https://console.hanzo.ai/v1/orgs/maxpower/entitlements')
+    expect(String(calledUrl)).toBe(`${API}/v1/orgs/maxpower/entitlements`)
     expect((init as RequestInit).method).toBe('POST')
     expect(JSON.parse(String((init as RequestInit).body))).toEqual({ add: ['agents'] })
   })

--- a/src/lib/guide/client.test.ts
+++ b/src/lib/guide/client.test.ts
@@ -10,13 +10,17 @@ import {
 
 /**
  * GuideBlueprintApi + pure normalizers + `strategyQuery` shaping. The SuperAdmin client
- * calls the cloud `/v1/guide/*` blueprint contract through the console's `/v1` user-bearer
- * proxy (`cloudProxyV1Url` → `<origin>/v1/guide/...` — the live-ingress-safe form for a
- * bearer-scoped head; a bare `/v1/guide` 403s on the gateway). These pin (1) that each call
- * hits the EXACT `/v1/guide/...` path + verb, (2) the real blueprint/profile/suggest JSON
- * normalizes, and (3) a garbage/absent field degrades to a safe default (never throws).
+ * calls the cloud `/v1/guide/*` blueprint contract on the CANONICAL API host
+ * (`cloudProxyV1Url` → `originV1Url` → `config.cloudUrl` = api.hanzo.ai) — the host is
+ * NAMED, not inherited from wherever the admin bundle is served, so the page origin below
+ * is irrelevant to it. These pin (1) that each call hits the EXACT `/v1/guide/...` path +
+ * verb on that host, (2) the real blueprint/profile/suggest JSON normalizes, and (3) a
+ * garbage/absent field degrades to a safe default (never throws).
  */
+/** The origin the admin SPA is served from — deliberately NOT where the API lives. */
 const ORIGIN = 'https://admin.hanzo.ai'
+/** The one API host every `/v1` call resolves against (config's CANONICAL_API_URL). */
+const API = 'https://api.hanzo.ai'
 
 describe('strategyQuery — the corpus filter querystring', () => {
   it('is empty for no filter or an all-empty filter', () => {
@@ -118,7 +122,7 @@ describe('blueprint normalizers — real cloud JSON, defensive', () => {
   })
 })
 
-describe('GuideBlueprintApi — hits the exact /v1/guide/* bearer-proxy paths', () => {
+describe('GuideBlueprintApi — hits the exact /v1/guide/* paths on the canonical API host', () => {
   const fetched: { url: string; method: string }[] = []
 
   beforeEach(() => {
@@ -139,34 +143,34 @@ describe('GuideBlueprintApi — hits the exact /v1/guide/* bearer-proxy paths', 
     delete (globalThis as { window?: unknown }).window
   })
 
-  it('reads the blueprint via the /v1 bearer BFF (prefix-free /v1)', async () => {
+  it('reads the blueprint at /v1/guide/blueprint (prefix-free /v1)', async () => {
     await GuideBlueprintApi.blueprint()
-    expect(fetched[0]).toEqual({ url: `${ORIGIN}/v1/guide/blueprint`, method: 'GET' })
+    expect(fetched[0]).toEqual({ url: `${API}/v1/guide/blueprint`, method: 'GET' })
   })
 
   it('PATCHes one item at /blueprint/:collection/:id (the enable/disable lever)', async () => {
     await GuideBlueprintApi.patchItem('steps', 'connect-analytics', { enabled: false })
-    expect(fetched[0]).toEqual({ url: `${ORIGIN}/v1/guide/blueprint/steps/connect-analytics`, method: 'PATCH' })
+    expect(fetched[0]).toEqual({ url: `${API}/v1/guide/blueprint/steps/connect-analytics`, method: 'PATCH' })
   })
 
   it('PUTs the whole blueprint to publish a version', async () => {
     await GuideBlueprintApi.publish({ version: 'v3' })
-    expect(fetched[0]).toEqual({ url: `${ORIGIN}/v1/guide/blueprint`, method: 'PUT' })
+    expect(fetched[0]).toEqual({ url: `${API}/v1/guide/blueprint`, method: 'PUT' })
   })
 
   it('reads the version history', async () => {
     await GuideBlueprintApi.versions()
-    expect(fetched[0]).toEqual({ url: `${ORIGIN}/v1/guide/blueprint/versions`, method: 'GET' })
+    expect(fetched[0]).toEqual({ url: `${API}/v1/guide/blueprint/versions`, method: 'GET' })
   })
 
   it('filters the corpus with the query facets', async () => {
     await GuideBlueprintApi.strategies({ category: 'acquisition', workload: 'content' })
-    expect(fetched[0]).toEqual({ url: `${ORIGIN}/v1/guide/strategies?category=acquisition&workload=content`, method: 'GET' })
+    expect(fetched[0]).toEqual({ url: `${API}/v1/guide/strategies?category=acquisition&workload=content`, method: 'GET' })
   })
 
   it('reads the live profile and the ranked suggestions', async () => {
     await GuideBlueprintApi.profile()
     await GuideBlueprintApi.suggest()
-    expect(fetched.map((f) => f.url)).toEqual([`${ORIGIN}/v1/guide/profile`, `${ORIGIN}/v1/guide/suggest`])
+    expect(fetched.map((f) => f.url)).toEqual([`${API}/v1/guide/profile`, `${API}/v1/guide/suggest`])
   })
 })

--- a/src/lib/referrals/claim.test.ts
+++ b/src/lib/referrals/claim.test.ts
@@ -5,10 +5,13 @@ import { stashReferralCode, claimReferralOnce, __resetReferralGuard } from './cl
 /**
  * Referral capture + claim — the signup-capture half. Uses a fetch stub (the real
  * client path, like crm.test.ts) so the test proves the ACTUAL POST to
- * `/v1/referrals/claim`, plus the localStorage capture + the once-per-session
- * guards.
+ * `/v1/referrals/claim` on the canonical API host, plus the localStorage capture +
+ * the once-per-session guards.
  */
+/** The origin the SPA is served from — deliberately NOT where the API lives. */
 const ORIGIN = 'https://console.hanzo.ai'
+/** The one API host every `/v1` call resolves against (config's CANONICAL_API_URL). */
+const API = 'https://api.hanzo.ai'
 
 function memStore() {
   const m = new Map<string, string>()
@@ -65,12 +68,12 @@ describe('referral capture + claim', () => {
     expect(ls.getItem('hz_ref')).toBeNull()
   })
 
-  it('claims a stashed code once, POSTing to the /v1 bearer BFF, then consumes it', async () => {
+  it('claims a stashed code once, POSTing to the canonical /v1, then consumes it', async () => {
     ls.setItem('hz_ref', 'ABC')
     claimReferralOnce('orgB')
     await flush()
     expect(fetched).toHaveLength(1)
-    expect(fetched[0].url).toBe(`${ORIGIN}/v1/referrals/claim`)
+    expect(fetched[0].url).toBe(`${API}/v1/referrals/claim`)
     expect(fetched[0].method).toBe('POST')
     expect(fetched[0].body).toContain('ABC')
     expect(ls.getItem('hz_ref')).toBeNull() // consumed on success


### PR DESCRIPTION
Every `/v1` call resolved against `window.location.origin`. That only *looked* like compliance with the one-endpoint rule — console.hanzo.ai and api.hanzo.ai are the same binary on the same address, so calls landed on the right server by coincidence of topology, not by anything in the code.

**Measured:** both hosts (and admin.hanzo.ai) answer `x-api-version: v1.801.480` with byte-identical bodies.

## The change

`cloudUrl()` drops the `window.location.origin` branch; `originV1Url` resolves against it. One base, and it is named: `api.hanzo.ai`, overridable via `NEXT_PUBLIC_CLOUD_URL` for local dev.

It reads `config.cloudUrl` and **not** `activeApiBase()` on purpose — a network is user-addable and persisted in localStorage, so letting that steer these paths would let a user-added network retarget the admin-gated surface. Deploy config may move this host; a user may not.

## Three broken surfaces fixed

`/tasksd`, `/training` and the CSRF mint were paths on the *serving* origin, and `scripts/build-embed.mjs` stashes every `app/**/route.ts` out of the static export the cloud binary serves. On console.hanzo.ai they matched no handler and fell into the SPA catch-all:

```
GET https://console.hanzo.ai/tasksd/health  -> 200 369706B text/html
GET https://console.hanzo.ai/training/x     -> 200 369706B text/html
```

`restGet` then threw parsing HTML as JSON, and the caller reported a backend error for a request that reached no backend. They now address the surfaces those proxies forwarded to, which already exist:

```
GET https://api.hanzo.ai/v1/tasks/health    -> 200 33B application/json
GET https://api.hanzo.ai/v1/ml/models       -> 403 (gated, reached)
GET https://api.hanzo.ai/v1/finetune/jobs   -> 401 (gated, reached)
```

## Auth was measured, not reasoned about

Verified in a browser against production with a real signed-in session (PKCE sign-in through hanzo.id, plus the already-has-a-session reload case).

- 14 of 16 representative paths byte-identical same- vs cross-origin.
- The 2 that differ **favour** cross-origin: `/v1/iam/get-account` returns `{"status":"error","msg":"please sign in first"}` on console.hanzo.ai and the real account on api.hanzo.ai.
- `credentials: 'omit'` still returns the account cross-origin, proving the **PKCE bearer** resolves identity, not the cookie. The `cloud_session_id` cookie is host-only (no `Domain=`), which is why that matters.

## ⚠️ Depends on a cloud CORS fix

Four headers the console stamps on signed-in calls are **not** in `Access-Control-Allow-Headers`, and each blocks the request cross-origin (opaque `TypeError: Failed to fetch`): `X-Actor-Id`, `X-Act-As-Project`, `X-Act-As-Org`, `X-CSRF-Token`.

Fixed in **hanzo-inc/cloud** `fix/cors-console-headers`. **That must ship first or this breaks signed-in users.**

## Not done, deliberately

The OSS App Store still reads `templates.hanzo.ai` (a live cross-origin data API, 200/499520B, wildcard CORS). It is a three-file surface (`meta.json` + blueprint logos + compose) and cloud has no `/v1/oss` head yet (404 today), so repointing it would break the store rather than move it.

## Tests

`3209 passed, 0 failed` (258 files), `tsc --noEmit` clean. 157 tests across 37 files encoded the old same-origin contract and were updated to the new one; `origin-url.test.ts` now pins that the result does **not** vary with page origin.