### PR TITLE
console: stop asking a retired head, a dead dialect, and blaming the wrong door

### DIFF
--- a/e2e/insights-o11y.spec.ts
+++ b/e2e/insights-o11y.spec.ts
@@ -52,31 +52,11 @@ const nowMs = Date.now()
 const win = { startNs: String((nowMs - 3_600_000) * 1e6), endNs: String(nowMs * 1e6), startMs: nowMs - 3_600_000, endMs: nowMs }
 const servicesBody = { start: win.startNs, end: win.endNs, tags: [] as unknown[] }
 const queryRangeBody = {
+  schemaVersion: 'v1',
   start: win.startMs,
   end: win.endMs,
-  step: 60,
-  compositeQuery: {
-    queryType: 'builder',
-    panelType: 'list',
-    builderQueries: {
-      A: {
-        queryName: 'A',
-        dataSource: 'logs',
-        aggregateOperator: 'noop',
-        aggregateAttribute: {},
-        expression: 'A',
-        disabled: false,
-        stepInterval: 60,
-        filters: { items: [], op: 'AND' },
-        groupBy: [],
-        having: [],
-        orderBy: [{ columnName: 'timestamp', order: 'desc' }],
-        limit: null,
-        offset: 0,
-        pageSize: 50,
-      },
-    },
-  },
+  requestType: 'raw',
+  compositeQuery: { queries: [{ type: 'builder_query', spec: { name: 'A', signal: 'logs', limit: 50, offset: 0 } }] },
 }
 
 /** Sign in via the console app sign-in form (email/password → session cookie). */

--- a/e2e/probe-o11y.spec.ts
+++ b/e2e/probe-o11y.spec.ts
@@ -59,16 +59,11 @@ const PROBES: Probe[] = [
     path: 'o11y/query_range',
     method: 'POST',
     body: {
+      schemaVersion: 'v1',
       start: startMs,
       end: endMs,
-      step: 60,
-      compositeQuery: {
-        queryType: 'builder',
-        panelType: 'list',
-        builderQueries: {
-          A: { queryName: 'A', dataSource: 'logs', aggregateOperator: 'noop', aggregateAttribute: {}, expression: 'A', disabled: false, stepInterval: 60, filters: { items: [], op: 'AND' }, groupBy: [], having: [], orderBy: [{ columnName: 'timestamp', order: 'desc' }], limit: null, offset: 0, pageSize: 50 },
-        },
-      },
+      requestType: 'raw',
+      compositeQuery: { queries: [{ type: 'builder_query', spec: { name: 'A', signal: 'logs', limit: 50, offset: 0 } }] },
     },
   },
   // ── Infra ──

--- a/src/components/products/LogsModule.tsx
+++ b/src/components/products/LogsModule.tsx
@@ -6,8 +6,8 @@
  *  1. APPLICATION logs (default) — full-text application/platform logs from the
  *     Hanzo o11y (O11y) runtime, read through the same-origin `/v1` bearer
  *     proxy as `POST /v1/o11y/query_range` (the version-less canonical o11y
- *     surface; a `list`-panel `noop` builder query over `dataSource: logs`, newest
- *     first — `ApmApi.logs`). Real
+ *     surface; a v5 `requestType: raw` builder query over `signal: logs`
+ *     — `ApmApi.logs`). Real
  *     log lines (time · severity · service · message), org-scoped by the minted
  *     bearer, filterable by severity + service. Honest states: loading, the
  *     shared o11y `RuntimeNotice` on 503/404/401/403, and an honest "connected ·

--- a/src/components/products/observability/RuntimeNotice.tsx
+++ b/src/components/products/observability/RuntimeNotice.tsx
@@ -8,6 +8,13 @@
  * never fabricate traces, sessions, scores, or charts — this card explains the
  * real reason and names the endpoint, so an empty observability area always reads
  * truthfully.
+ *
+ * The endpoint it names comes off `ApiError.endpoint` — the URL the failed request
+ * was actually sent to. It used to be synthesized from the `surface` prop, which is a
+ * DISPLAY label ("logs", "traces", "scores"), so the card confidently printed
+ * `/v1/o11y/logs` for a failure at `/v1/o11y/query_range`. `/v1/o11y/logs` is a real
+ * route that 405s a POST, which makes the wrong answer look like a lead, and someone
+ * chased it. A label is not an address: when the error carries no path we print none.
  */
 import { Button, Card, Text, XStack } from '@hanzo/gui'
 import { BarChart3, TriangleAlert } from '@hanzogui/lucide-icons-2'
@@ -41,12 +48,20 @@ const TITLE: Record<RuntimeStatus, string> = {
   error: 'Could not reach observability',
 }
 
+/** The path the failed request was sent to, or '' when the error carries none. */
+export function failedEndpoint(e: unknown): string {
+  return e instanceof ApiError ? e.endpoint : ''
+}
+
 export function RuntimeNotice({ surface, error }: { surface: string; error: unknown }) {
   const status = classifyRuntime(error)
   const message = error instanceof Error ? error.message : String(error)
+  const endpoint = failedEndpoint(error)
   const body: Record<RuntimeStatus, string> = {
     'not-initialized': `Observability runtime initializing — your ${surface} will appear here once it's enabled. The /v1/o11y routes are mounted, but the runtime (telemetry stores, query service) is not initialized on this deployment yet. This page shows live ${surface} the moment the runtime is online — it never shows placeholder data.`,
-    unavailable: `The /v1/o11y/${surface} surface is not proxied on this host yet.`,
+    unavailable: endpoint
+      ? `${endpoint} is not routed on this host yet, so your ${surface} can't be read.`
+      : `The observability surface behind your ${surface} is not routed on this host yet.`,
     // 403 for a signed-in user — observability isn't provisioned for their org.
     access: `Observability isn't enabled for your organization yet, so your ${surface} can't be read. It appears here automatically once it is — never placeholder data.`,
     // 401 — the session itself lapsed.
@@ -80,7 +95,8 @@ export function RuntimeNotice({ surface, error }: { surface: string; error: unkn
         </Button>
       ) : null}
       <Text fontSize="$2" color="$color10">
-        endpoint · /v1/o11y/{surface} · {config.brandName}
+        {endpoint ? `endpoint · ${endpoint} · ` : ''}
+        {config.brandName}
       </Text>
     </Card>
   )

--- a/src/components/products/subpage/ProductLogsView.tsx
+++ b/src/components/products/subpage/ProductLogsView.tsx
@@ -4,9 +4,8 @@
  * Per-product Logs — the LIVE application/platform logs for THIS product's OTel
  * service, read from the Hanzo o11y (O11y) runtime via the same-origin `/v1`
  * bearer proxy (`POST /v1/o11y/query_range` — the version-less canonical o11y
- * surface; a `list`-panel `noop` builder query over `dataSource: logs`, newest first,
- * FILTERED to the product's
- * `service.name`). The SAME o11y source the Observe › Logs board reads, scoped to
+ * surface; a v5 `requestType: raw` builder query over `signal: logs`, FILTERED to the
+ * product's `service.name`). The SAME o11y source the Observe › Logs board reads, scoped to
  * one product — org-scoped by the minted bearer, so a customer sees only their own
  * org's lines (o11y scopes every query by the JWT owner → `X-Org-Id`).
  *

--- a/src/lib/api/apm-service-scope.test.ts
+++ b/src/lib/api/apm-service-scope.test.ts
@@ -4,6 +4,11 @@
  * asserts BOTH that the per-product query is BUILT with the service filter AND that a
  * realistic O11y response is MAPPED to real, service-scoped view-models. This is the
  * "the query builds + maps real responses" gate for the per-product Status/Logs/Metrics.
+ *
+ * The request bodies and responses here are the o11y v5 dialect — `compositeQuery.queries`
+ * out, `data.data.results[].rows` back. The v3 shapes this file used to carry were not
+ * merely stale: the server 400s them, so the suite was proving the console could build a
+ * request production had never once accepted.
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 
@@ -17,26 +22,48 @@ vi.mock('./client', () => ({
 
 import { ApmApi, apmWindow } from './apm'
 
-type Body = { compositeQuery: { builderQueries: { A: { filters: { items: { op: string; value: string; key: { key: string } }[] } } } } }
+type Spec = { name: string; signal: string; limit: number; offset: number; filter?: { expression: string }; order?: unknown[] }
+type Body = { requestType: string; compositeQuery: { queries: { type: string; spec: Spec }[] } }
+
+/** A v5 `requestType: raw` response, as the server sends it. */
+const rawResponse = (rows: unknown[]): unknown => ({
+  status: 'success',
+  data: { type: 'raw', data: { results: [{ queryName: 'A', rows }] } },
+})
+
+/** The single builder-query spec the call put on the wire. Fails loudly rather than
+ *  returning undefined, so a test that resolved NO request can never read as a pass. */
+function sentSpec(): Spec {
+  expect(restPost.mock.calls.length, 'no request was sent — there is nothing to assert about').toBeGreaterThan(0)
+  const [, body] = restPost.mock.calls[0] as [string, Body]
+  const queries = body?.compositeQuery?.queries
+  expect(Array.isArray(queries) && queries.length > 0, 'the body carried no compositeQuery.queries').toBe(true)
+  return queries[0].spec
+}
 
 describe('ApmApi.logs — the per-product o11y query builds with the service filter + maps real rows', () => {
   beforeEach(() => restPost.mockReset())
 
   it('sends a service.name filter and normalizes a real O11y logs response to service-scoped rows', async () => {
-    const nsTs = String(Date.parse('2026-07-03T00:00:00Z') * 1_000_000) // O11y ns epoch
-    restPost.mockResolvedValueOnce({
-      data: { result: [{ list: [{ timestamp: nsTs, data: { id: 'l1', severity_text: 'INFO', 'service.name': 'iam', body: 'signed in' } }] }] },
-    })
+    restPost.mockResolvedValueOnce(
+      rawResponse([
+        {
+          timestamp: '2026-07-03T00:00:00Z',
+          data: { id: 'l1', severity_text: 'INFO', body: 'signed in', resources_string: { 'service.name': 'iam' } },
+        },
+      ]),
+    )
 
     const rows = await ApmApi.logs(apmWindow(3600), 500, 'iam')
 
-    // 1) the outgoing query carried the per-service filter (serviceFilterItem)
+    // 1) the outgoing query carried the per-service filter expression
     const [url, body] = restPost.mock.calls[0] as [string, Body]
     // Version-less canonical o11y surface, addressed via the /v1 bearer BFF.
     expect(url).toBe('/v1/o11y/query_range')
-    const items = body.compositeQuery.builderQueries.A.filters.items
-    expect(items).toHaveLength(1)
-    expect(items[0]).toMatchObject({ op: '=', value: 'iam', key: { key: 'service.name' } })
+    expect(body.requestType).toBe('raw')
+    const spec = sentSpec()
+    expect(spec.signal).toBe('logs')
+    expect(spec.filter).toEqual({ expression: "service.name = 'iam'" })
 
     // 2) the real response maps to real, normalized rows
     expect(rows).toHaveLength(1)
@@ -44,21 +71,31 @@ describe('ApmApi.logs — the per-product o11y query builds with the service fil
   })
 
   it('re-filters client-side so a runtime that ignored the filter cannot leak another service onto the page', async () => {
-    restPost.mockResolvedValueOnce({
-      data: { result: [{ list: [
-        { timestamp: '2', data: { body: 'mine', 'service.name': 'iam' } },
-        { timestamp: '1', data: { body: 'not mine', 'service.name': 'kms' } },
-      ] }] },
-    })
+    restPost.mockResolvedValueOnce(
+      rawResponse([
+        { timestamp: '2', data: { body: 'mine', resources_string: { 'service.name': 'iam' } } },
+        { timestamp: '1', data: { body: 'not mine', resources_string: { 'service.name': 'kms' } } },
+      ]),
+    )
     const rows = await ApmApi.logs(apmWindow(3600), 500, 'iam')
     expect(rows.map((r) => r.body)).toEqual(['mine'])
   })
 
-  it('sends NO filter for the org-wide stream (back-compat with the Observe Logs board)', async () => {
-    restPost.mockResolvedValueOnce({ data: { result: [] } })
+  it('sends NO filter for the org-wide stream (the Observe Logs board)', async () => {
+    restPost.mockResolvedValueOnce(rawResponse([]))
     await ApmApi.logs(apmWindow(3600), 500)
-    const [, body] = restPost.mock.calls[0] as [string, Body]
-    expect(body.compositeQuery.builderQueries.A.filters.items).toEqual([])
+    const spec = sentSpec()
+    expect(spec.signal).toBe('logs')
+    expect(spec.filter).toBeUndefined()
+  })
+
+  it('scopes a trace search the same way, over signal: traces', async () => {
+    restPost.mockResolvedValueOnce(rawResponse([{ timestamp: '1', data: { span_id: 's1', trace_id: 't1', name: 'op', resources_string: { 'service.name': 'gateway' } } }]))
+    const spans = await ApmApi.traceSearch(apmWindow(3600), 50, 'gateway')
+    const spec = sentSpec()
+    expect(spec.signal).toBe('traces')
+    expect(spec.filter).toEqual({ expression: "service.name = 'gateway'" })
+    expect(spans.map((s) => s.service)).toEqual(['gateway'])
   })
 })
 

--- a/src/lib/api/apm.test.ts
+++ b/src/lib/api/apm.test.ts
@@ -15,7 +15,7 @@ import {
   normalizeDashboard,
   normalizeDashboards,
   listQueryPayload,
-  serviceFilterItem,
+  serviceFilterExpression,
   pickService,
   serviceHealthOf,
   parseListRows,
@@ -234,65 +234,153 @@ describe('normalizeDashboard / normalizeDashboards', () => {
   })
 })
 
-describe('listQueryPayload (O11y v3 query_range LIST)', () => {
-  const w = apmWindow(3600)
+// ── The o11y v5 query_range contract, transcribed from the SERVER ─────────────
+//
+// These literals come from `QueryRangeRequest` / `CompositeQuery` / `QueryEnvelope` in
+// github.com/hanzoai/o11y v1.5.58 — the server's own definition of what it will accept.
+// They are deliberately NOT imported from `./apm`. The suite this replaced imported the
+// builder and then asserted that the builder built what the builder was written to build
+// (`p.compositeQuery.queryType === 'builder'`), which is true of any builder and stayed
+// green for as long as it took someone to notice that production had been answering 400
+// to every Logs and Traces load. A payload test is only worth running if the expectation
+// comes from the other side of the wire.
 
-  it('builds a noop list builder query over the given dataSource with ms bounds', () => {
-    const p = listQueryPayload('logs', w, 100) as {
-      start: number
-      end: number
-      compositeQuery: { queryType: string; panelType: string; builderQueries: Record<string, Record<string, unknown>> }
+/** `QueryRangeRequest.requestType` — the accepted result kinds. */
+const REQUEST_TYPES = ['scalar', 'time_series', 'raw', 'raw_stream', 'trace', 'distribution']
+/** `QueryEnvelope.type` — the accepted query kinds. Note `builder` is NOT one of them. */
+const QUERY_TYPES = [
+  'builder_query',
+  'builder_formula',
+  'builder_sub_query',
+  'builder_join',
+  'builder_trace_operator',
+  'promql',
+  'datastore_sql',
+]
+/** `CompositeQuery` has exactly ONE field. Anything else is rejected by name. */
+const COMPOSITE_FIELDS = ['queries']
+/**
+ * The retired v3 envelope, field by field. The server refuses each of these explicitly
+ * (`400 unknown field "queryType" in composite query`, then "panelType", then
+ * "builderQueries"), so any one of them anywhere in the body is a 400 waiting to ship.
+ */
+const V3_KEYS = ['queryType', 'panelType', 'builderQueries', 'dataSource', 'aggregateOperator']
+
+/**
+ * Every object key in a JSON tree, in visit order. Arrays are walked as containers, so a
+ * key buried in `compositeQuery.queries[0].spec.filter` is still seen — a check that
+ * only looked at the top level would quietly stop matching the moment the shape nested.
+ */
+function everyKey(v: unknown, out: string[] = []): string[] {
+  if (Array.isArray(v)) {
+    for (const x of v) everyKey(x, out)
+    return out
+  }
+  if (v && typeof v === 'object') {
+    for (const [k, x] of Object.entries(v as Record<string, unknown>)) {
+      out.push(k)
+      everyKey(x, out)
     }
-    expect(p.start).toBe(w.startMs)
-    expect(p.end).toBe(w.endMs)
-    expect(p.compositeQuery.queryType).toBe('builder')
-    expect(p.compositeQuery.panelType).toBe('list')
-    const A = p.compositeQuery.builderQueries.A
-    expect(A.dataSource).toBe('logs')
-    expect(A.aggregateOperator).toBe('noop')
-    expect(A.expression).toBe('A')
-    expect(A.pageSize).toBe(100)
-    // newest-first
-    expect(A.orderBy).toEqual([{ columnName: 'timestamp', order: 'desc' }])
-  })
+  }
+  return out
+}
 
-  it('carries dataSource=traces for a span search', () => {
-    const p = listQueryPayload('traces', w, 50) as { compositeQuery: { builderQueries: { A: { dataSource: string } } } }
-    expect(p.compositeQuery.builderQueries.A.dataSource).toBe('traces')
+describe('everyKey (the forbidden-key walk itself)', () => {
+  it('descends through objects AND arrays, so nothing hides below the top level', () => {
+    expect(everyKey({ a: 1, b: { c: [{ d: 2 }] } })).toEqual(['a', 'b', 'c', 'd'])
   })
-
-  it('clamps pageSize into [1,1000] and floors it', () => {
-    const big = listQueryPayload('logs', w, 99999) as { compositeQuery: { builderQueries: { A: { pageSize: number } } } }
-    const zero = listQueryPayload('logs', w, 0) as { compositeQuery: { builderQueries: { A: { pageSize: number } } } }
-    const frac = listQueryPayload('logs', w, 12.9) as { compositeQuery: { builderQueries: { A: { pageSize: number } } } }
-    expect(big.compositeQuery.builderQueries.A.pageSize).toBe(1000)
-    expect(zero.compositeQuery.builderQueries.A.pageSize).toBe(1)
-    expect(frac.compositeQuery.builderQueries.A.pageSize).toBe(12)
-  })
-
-  it('defaults to NO filters (whole-org stream) when none are given — back-compat', () => {
-    const p = listQueryPayload('logs', w, 100) as { compositeQuery: { builderQueries: { A: { filters: { items: unknown[]; op: string } } } } }
-    expect(p.compositeQuery.builderQueries.A.filters).toEqual({ items: [], op: 'AND' })
-  })
-
-  it('carries a per-service filter into the builder query when given (per-product scope)', () => {
-    const item = serviceFilterItem('logs', 'iam')
-    const p = listQueryPayload('logs', w, 100, [item]) as { compositeQuery: { builderQueries: { A: { filters: { items: unknown[]; op: string } } } } }
-    expect(p.compositeQuery.builderQueries.A.filters).toEqual({ items: [item], op: 'AND' })
+  it('returns [] for a leaf — which is why every caller asserts it found keys', () => {
+    expect(everyKey(null)).toEqual([])
+    expect(everyKey('nope')).toEqual([])
   })
 })
 
-describe('serviceFilterItem (scope a logs/traces query to one OTel service.name)', () => {
-  it('builds the service.name resource-attribute equality O11y expects', () => {
-    const f = serviceFilterItem('logs', 'vector')
-    expect(f.op).toBe('=')
-    expect(f.value).toBe('vector')
-    expect(f.key.key).toBe('service.name')
-    expect(f.key.type).toBe('resource')
-    expect(f.key.isColumn).toBe(false) // logs: resource attribute, not an indexed column
+describe('listQueryPayload — pinned to the o11y v5 query_range contract', () => {
+  const w = apmWindow(3600)
+  /** The payload as it goes over the WIRE: `JSON.stringify` is what the transport sends,
+   *  and it is where an `undefined`-valued key disappears. Assert on that, not on the
+   *  in-memory object the server never sees. */
+  const wire = (signal: 'logs' | 'traces', limit: number, service?: string): Record<string, unknown> =>
+    JSON.parse(JSON.stringify(listQueryPayload(signal, w, limit, service))) as Record<string, unknown>
+
+  const cases = [
+    { name: 'org-wide logs', body: wire('logs', 100) },
+    { name: 'service-scoped logs', body: wire('logs', 100, 'iam') },
+    { name: 'org-wide traces', body: wire('traces', 50) },
+    { name: 'service-scoped traces', body: wire('traces', 50, 'gateway') },
+  ]
+
+  it('emits a requestType the server accepts, on every payload it can build', () => {
+    expect(cases.length, 'no payloads under test — this asserts nothing').toBeGreaterThan(0)
+    for (const c of cases) {
+      expect(REQUEST_TYPES, `${c.name}: requestType must be one the server accepts`).toContain(c.body.requestType)
+    }
   })
-  it('marks service.name as an indexed column for traces (where it is materialized)', () => {
-    expect(serviceFilterItem('traces', 'gateway').key.isColumn).toBe(true)
+
+  it('compositeQuery carries ONLY `queries`, a non-empty array of accepted envelopes', () => {
+    for (const c of cases) {
+      const composite = c.body.compositeQuery as Record<string, unknown>
+      expect(composite, `${c.name}: compositeQuery is missing`).toBeTruthy()
+      expect(Object.keys(composite).sort(), `${c.name}: compositeQuery must have exactly one field`).toEqual(COMPOSITE_FIELDS)
+      const queries = composite.queries as { type?: unknown }[]
+      expect(Array.isArray(queries), `${c.name}: compositeQuery.queries must be an array`).toBe(true)
+      expect(queries.length, `${c.name}: compositeQuery.queries is empty — no envelope was inspected`).toBeGreaterThan(0)
+      for (const q of queries) {
+        expect(QUERY_TYPES, `${c.name}: envelope type must be one the server accepts`).toContain(q.type)
+      }
+    }
+  })
+
+  it('no v3 envelope key survives ANYWHERE in the serialized body', () => {
+    for (const c of cases) {
+      const keys = everyKey(c.body)
+      expect(keys.length, `${c.name}: the key walk visited nothing, so it proves nothing`).toBeGreaterThan(0)
+      expect(keys.filter((k) => V3_KEYS.includes(k)), `${c.name}: retired v3 keys must not reach the wire`).toEqual([])
+    }
+  })
+
+  it('describes the read: schemaVersion, the ms window, the signal, and the page', () => {
+    const p = wire('logs', 100)
+    expect(p.schemaVersion).toBe('v1')
+    expect(p.start).toBe(w.startMs)
+    expect(p.end).toBe(w.endMs)
+    expect(p.requestType).toBe('raw') // whole rows back, not an aggregate
+    const spec = ((p.compositeQuery as { queries: { spec: Record<string, unknown> }[] }).queries[0]).spec
+    expect(spec.name).toBe('A')
+    expect(spec.signal).toBe('logs')
+    expect(spec.limit).toBe(100)
+    expect(spec.offset).toBe(0)
+    expect(wire('traces', 50).compositeQuery).toMatchObject({ queries: [{ spec: { signal: 'traces' } }] })
+  })
+
+  it('clamps the row limit into [1,1000] and floors it', () => {
+    const limitOf = (n: number): unknown =>
+      ((wire('logs', n).compositeQuery as { queries: { spec: { limit: unknown } }[] }).queries[0]).spec.limit
+    expect(limitOf(99999)).toBe(1000)
+    expect(limitOf(0)).toBe(1)
+    expect(limitOf(12.9)).toBe(12)
+  })
+
+  it('the org-wide stream carries no filter and no order (nothing to scope)', () => {
+    const spec = ((wire('logs', 100).compositeQuery as { queries: { spec: Record<string, unknown> }[] }).queries[0]).spec
+    expect(spec.filter).toBeUndefined()
+    expect(spec.order).toBeUndefined()
+  })
+
+  it('a service scope adds the v5 filter EXPRESSION and a newest-first order', () => {
+    const spec = ((wire('logs', 100, 'iam').compositeQuery as { queries: { spec: Record<string, unknown> }[] }).queries[0]).spec
+    expect(spec.filter).toEqual({ expression: "service.name = 'iam'" })
+    expect(spec.order).toEqual([{ key: { name: 'timestamp' }, direction: 'desc' }])
+  })
+})
+
+describe('serviceFilterExpression (scope a logs/traces query to one OTel service.name)', () => {
+  it('builds the v5 filter expression — one string, not a v3 {key,op,value} item', () => {
+    expect(serviceFilterExpression('vector')).toBe("service.name = 'vector'")
+  })
+  it('escapes the backslash and the quote so a name cannot break out of the literal', () => {
+    expect(serviceFilterExpression("it's")).toBe("service.name = 'it\\'s'")
+    expect(serviceFilterExpression('a\\b')).toBe("service.name = 'a\\\\b'")
   })
 })
 
@@ -338,20 +426,30 @@ describe('serviceHealthOf (RED verdict for one service)', () => {
   })
 })
 
+/** A v5 `requestType: raw` response, as the server sends it. */
+const rawResponse = (rows: unknown[]): unknown => ({
+  status: 'success',
+  data: { type: 'raw', data: { results: [{ queryName: 'A', rows }] } },
+})
+
 describe('parseListRows', () => {
-  it('reads rows from data.result[].list', () => {
-    const body = { data: { result: [{ list: [{ timestamp: '1', data: { body: 'a' } }, { timestamp: '2', data: { body: 'b' } }] }] } }
+  it('reads rows from the v5 location data.data.results[].rows', () => {
+    const body = rawResponse([{ timestamp: '1', data: { body: 'a' } }, { timestamp: '2', data: { body: 'b' } }])
     expect(parseListRows(body)).toHaveLength(2)
   })
-  it('reads rows from the nested data.newResult.data.result[].list mirror', () => {
-    const body = { data: { newResult: { data: { result: [{ list: [{ timestamp: '1', data: {} }] }] } } } }
-    expect(parseListRows(body)).toHaveLength(1)
+  it('concatenates the rows of every result in the response', () => {
+    const body = { data: { data: { results: [{ queryName: 'A', rows: [{ data: {} }] }, { queryName: 'B', rows: [{ data: {} }, { data: {} }] }] } } }
+    expect(parseListRows(body)).toHaveLength(3)
+  })
+  it('does NOT read the retired v3 locations — one shape, and it is the current one', () => {
+    expect(parseListRows({ data: { result: [{ list: [{ timestamp: '1', data: { body: 'a' } }] }] } })).toEqual([])
+    expect(parseListRows({ data: { newResult: { data: { result: [{ list: [{ timestamp: '1', data: {} }] }] } } } })).toEqual([])
   })
   it('returns [] for empty/garbage/missing shapes (never throws)', () => {
     expect(parseListRows(null)).toEqual([])
     expect(parseListRows({})).toEqual([])
-    expect(parseListRows({ data: { result: null } })).toEqual([])
-    expect(parseListRows({ data: { result: [{ list: null }] } })).toEqual([])
+    expect(parseListRows({ data: { data: { results: null } } })).toEqual([])
+    expect(parseListRows({ data: { data: { results: [{ rows: null }] } } })).toEqual([])
     expect(parseListRows('nope')).toEqual([])
   })
 })
@@ -402,15 +500,38 @@ describe('normalizeLogRow / normalizeLogs', () => {
     expect(l.body).toBe('hi')
     expect(l.id).toBe('5-3') // ts-idx fallback
   })
-  it('maps a full query_range logs response, newest-first order preserved', () => {
-    const body = {
-      data: { result: [{ list: [{ timestamp: '2', data: { body: 'newer' } }, { timestamp: '1', data: { body: 'older' } }] }] },
-    }
-    const rows = normalizeLogs(body)
+  it('lifts service.name out of the v5 resources_string map (it is a RESOURCE attribute)', () => {
+    const l = normalizeLogRow(
+      {
+        timestamp: '2026-07-03T00:00:00Z',
+        data: {
+          body: 'request served',
+          severity_text: 'INFO',
+          resources_string: { 'service.name': 'cloud-api', 'deployment.environment': 'main' },
+          attributes_string: { 'client.address': '10.0.0.1', 'http.request.method': 'GET' },
+        },
+      },
+      0,
+    )
+    expect(l.service).toBe('cloud-api')
+    expect(l.body).toBe('request served')
+    expect(l.severity).toBe('info')
+  })
+  it('leaves service empty when the row carries no service.name anywhere (never invented)', () => {
+    const l = normalizeLogRow({ timestamp: 5, data: { body: 'orphan', attributes_string: { error: 'boom' } } }, 0)
+    expect(l.service).toBe('')
+    expect(l.body).toBe('orphan')
+  })
+  it('prefers a materialized top-level column over a same-named nested attribute', () => {
+    const l = normalizeLogRow({ timestamp: 1, data: { body: 'column', attributes_string: { body: 'attribute' } } }, 0)
+    expect(l.body).toBe('column')
+  })
+  it('maps a full v5 query_range logs response, newest-first order preserved', () => {
+    const rows = normalizeLogs(rawResponse([{ timestamp: '2', data: { body: 'newer' } }, { timestamp: '1', data: { body: 'older' } }]))
     expect(rows.map((r) => r.body)).toEqual(['newer', 'older'])
   })
   it('empty result → empty list (honest empty, not a throw)', () => {
-    expect(normalizeLogs({ data: { result: [] } })).toEqual([])
+    expect(normalizeLogs(rawResponse([]))).toEqual([])
   })
 })
 
@@ -432,8 +553,26 @@ describe('normalizeTraceSpan / normalizeSpans', () => {
     expect(normalizeTraceSpan({ data: { spanID: 's' } }, 0).durationNano).toBeNull()
     expect(normalizeTraceSpan({ data: { spanID: 's', durationNano: '' } }, 0).durationNano).toBeNull()
   })
-  it('maps a full query_range traces response', () => {
-    const body = { data: { result: [{ list: [{ timestamp: '1', data: { traceID: 't', name: 'op' } }] }] } }
-    expect(normalizeSpans(body)).toHaveLength(1)
+  it('reads the v5 trace column names (trace_id / span_id / duration_nano / service.name)', () => {
+    const s = normalizeTraceSpan(
+      {
+        timestamp: '2026-07-03T00:00:00Z',
+        data: {
+          trace_id: 't1',
+          span_id: 's1',
+          name: 'GET /v1/chat',
+          duration_nano: 12345,
+          resources_string: { 'service.name': 'gateway' },
+        },
+      },
+      0,
+    )
+    expect(s.id).toBe('s1')
+    expect(s.traceId).toBe('t1')
+    expect(s.service).toBe('gateway')
+    expect(s.durationNano).toBe(12345)
+  })
+  it('maps a full v5 query_range traces response', () => {
+    expect(normalizeSpans(rawResponse([{ timestamp: '1', data: { trace_id: 't', name: 'op' } }]))).toHaveLength(1)
   })
 })

--- a/src/lib/api/apm.ts
+++ b/src/lib/api/apm.ts
@@ -532,124 +532,118 @@ export function normalizeDashboards(body: unknown): Dashboard[] {
   return rows.map(normalizeDashboard).filter((d) => d.uuid !== '')
 }
 
-// ── Logs + Traces (O11y composite query_range) ──────────────────────────────
+// ── Logs + Traces (O11y v5 query_range) ─────────────────────────────────────
 //
 // The universal `POST /v1/o11y/query_range` builder query (version-less canonical
-// surface). A `list`-panel `noop` query over `dataSource: logs | traces` returns RAW
-// rows (recent log lines / spans), newest first — the one true logs/traces read.
-// Time is epoch MILLISECONDS = `ApmWindow.startMs/endMs`. Every helper is pure (JSON
-// in, view-model out) so it unit-tests without a live runtime.
+// surface). A `raw` request over `signal: logs | traces` returns whole rows — recent
+// log lines / spans — which is the one true logs/traces read. Time is epoch
+// MILLISECONDS = `ApmWindow.startMs/endMs`. Every helper is pure (JSON in, view-model
+// out) so it unit-tests without a live runtime.
+//
+// The wire dialect is o11y v5 (`github.com/hanzoai/o11y` v1.5.58, `QueryRangeRequest`):
+//   { schemaVersion, start, end, requestType, compositeQuery: { queries: [ {type, spec} ] } }
+// `compositeQuery` carries EXACTLY ONE field, `queries`. The v3 envelope this file used
+// to send — `compositeQuery.{queryType,panelType,builderQueries}`, each query described
+// by `dataSource` + `aggregateOperator` — does not exist server-side any more, and the
+// server rejects it one field at a time: 400 `unknown field "queryType" in composite
+// query`, then `panelType`, then `builderQueries`. Nothing on the deployed server still
+// speaks v3, so there is no compatibility shim here either — ONE shape, the current one.
 
-/** The telemetry signal a builder query reads. */
-export type O11yDataSource = 'logs' | 'traces' | 'metrics'
+/** The telemetry signal a builder query reads (v5 `signal`; the v3 name was `dataSource`). */
+export type O11ySignal = 'logs' | 'traces'
 
 /**
- * One O11y builder-query filter item — the `{key, op, value}` shape the explorer
- * sends. `key` carries the attribute's name + type so the runtime resolves it
- * correctly (a resource attribute vs an indexed column).
+ * Scope a logs/traces query to ONE OpenTelemetry `service.name`.
+ *
+ * A v5 filter is an EXPRESSION — one string the server parses — not v3's list of
+ * `{key, op, value}` items. That also retires a piece of knowledge the client had no
+ * business holding: v3 made us declare whether `service.name` was a plain resource
+ * attribute (logs) or a materialized indexed column (traces). Which storage the field
+ * lives in is the server's business, and now it stays there.
+ *
+ * The backslash and the single quote are escaped, in that order, so a service name can
+ * never break out of the string literal.
  */
-export type QueryFilterItem = {
-  key: { key: string; dataType: 'string'; type: string; isColumn: boolean }
-  op: string
-  value: string
+export function serviceFilterExpression(service: string): string {
+  return `service.name = '${service.replace(/\\/g, '\\\\').replace(/'/g, "\\'")}'`
 }
 
 /**
- * Filter a logs/traces list query to ONE OpenTelemetry `service.name`. `service.name`
- * is a RESOURCE attribute on both signals (on traces it is also materialized as an
- * indexed column, so `isColumn` is set there) — this is the exact filter item O11y's
- * own explorer emits for a service-scoped list, so the runtime resolves it and never
- * 400s. The caller ALSO re-filters the normalized rows client-side (belt-and-suspenders),
- * so a runtime that ignores the item can never leak another service's rows onto a
- * per-product page.
- */
-export function serviceFilterItem(dataSource: O11yDataSource, service: string): QueryFilterItem {
-  return {
-    key: { key: 'service.name', dataType: 'string', type: 'resource', isColumn: dataSource === 'traces' },
-    op: '=',
-    value: service,
-  }
-}
-
-/**
- * The `list`-panel `selectColumns` per signal. The traces v4 list builder HARD-fails
- * (`select columns cannot be empty for panelType list`, → 500) when a noop list query
- * carries no `selectColumns`; the query already emits timestamp/spanID/traceID, so
- * these ADD the display fields `normalizeTraceSpan` reads. Each name is a materialized
- * static trace column (o11y `StaticFieldsTraces`), so the runtime resolves it verbatim.
- * Logs list does NOT require selectColumns (its noop path returns the default row set),
- * so it stays empty — adding trace columns there would reference non-existent log columns.
- */
-const listSelectColumns: Record<O11yDataSource, Array<Record<string, unknown>>> = {
-  traces: [
-    { key: 'name', dataType: 'string', type: 'tag', isColumn: true },
-    { key: 'duration_nano', dataType: 'float64', type: 'tag', isColumn: true },
-    { key: 'response_status_code', dataType: 'string', type: 'tag', isColumn: true },
-  ],
-  logs: [],
-  metrics: [],
-}
-
-/**
- * The exact v3 `query_range` LIST payload — ONE `noop` builder query keyed `A`,
- * newest-first, paged by `offset`/`pageSize`. Mirrors what O11y's own explorer
- * sends (verified against the frontend + the server `BuilderQuery` struct), so the
- * runtime never 400s on shape. `filters` (default none) scopes the query — e.g. a
- * `serviceFilterItem` restricts it to one product's OTel service. `selectColumns`
- * is REQUIRED by the traces list builder (empty → 500); see `listSelectColumns`.
+ * The `query_range` RAW-rows payload — ONE builder query named `A` over `signal`, paged
+ * by `limit`/`offset`. `requestType: 'raw'` is the field that asks for whole rows back
+ * (v3 spelled the same intent as the pair `panelType: 'list'` + `aggregateOperator: 'noop'`).
+ *
+ * A `service` scopes it to one product's OTel service, which adds the canonical `filter`
+ * and `order` to the spec. Both are REFUSED by the deployed server today — see the
+ * measured note above `ApmApi.logs`. We send them anyway, because they are the correct
+ * query and the defect is not here: a client that quietly dropped them would serve an
+ * unscoped log stream under a per-product heading and call that success.
  */
 export function listQueryPayload(
-  dataSource: O11yDataSource,
+  signal: O11ySignal,
   w: ApmWindow,
   limit: number,
-  filters: QueryFilterItem[] = [],
+  service?: string,
 ): Record<string, unknown> {
-  const pageSize = Math.max(1, Math.min(1000, Math.floor(limit)))
+  const rows = Math.max(1, Math.min(1000, Math.floor(limit)))
+  const spec: Record<string, unknown> = { name: 'A', signal, limit: rows, offset: 0 }
+  if (service) {
+    spec.filter = { expression: serviceFilterExpression(service) }
+    spec.order = [{ key: { name: 'timestamp' }, direction: 'desc' }]
+  }
   return {
+    schemaVersion: 'v1',
     start: w.startMs,
     end: w.endMs,
-    step: 60,
-    compositeQuery: {
-      queryType: 'builder',
-      panelType: 'list',
-      builderQueries: {
-        A: {
-          queryName: 'A',
-          dataSource,
-          aggregateOperator: 'noop',
-          aggregateAttribute: {},
-          expression: 'A',
-          disabled: false,
-          stepInterval: 60,
-          filters: { items: filters, op: 'AND' },
-          selectColumns: listSelectColumns[dataSource],
-          groupBy: [],
-          having: [],
-          orderBy: [{ columnName: 'timestamp', order: 'desc' }],
-          limit: null,
-          offset: 0,
-          pageSize,
-        },
-      },
-    },
+    requestType: 'raw',
+    compositeQuery: { queries: [{ type: 'builder_query', spec }] },
   }
 }
 
-/** A `list`-panel query returns rows under `data.result[].list` (newer runtimes
- *  mirror them under `data.newResult.data.result[].list`); each is `{timestamp,data}`. */
+/** One row of a v5 `raw` result: the row's time plus `data`, which holds the row's
+ *  columns (`body`, `severity_text`, …) and the nested attribute maps. */
 type ListRow = { timestamp?: string | number; data?: Record<string, unknown> | null }
 
-/** Pull the flat list rows out of either result location, never throwing on shape. */
+/**
+ * Pull the raw rows out of a v5 response, never throwing on shape. The rows live at
+ * `data.data.results[].rows[]`:
+ *   {"status":"success","data":{"type":"raw","data":{"results":[{"queryName":"A",
+ *    "rows":[{"timestamp":…,"data":{…}}]}]}}}
+ * (v3 put them at `data.result[].list`, mirrored at `data.newResult.data.result[].list`.
+ * Both locations went away with the dialect, so neither is read here.)
+ */
 export function parseListRows(body: unknown): ListRow[] {
-  const r = (body ?? {}) as { data?: { result?: unknown; newResult?: { data?: { result?: unknown } } } }
-  const direct = r?.data?.result
-  const nested = r?.data?.newResult?.data?.result
-  const results = (Array.isArray(direct) ? direct : Array.isArray(nested) ? nested : []) as { list?: unknown }[]
+  const results = (body as { data?: { data?: { results?: unknown } } } | null | undefined)?.data?.data?.results
+  if (!Array.isArray(results)) return []
   const out: ListRow[] = []
   for (const res of results) {
-    if (Array.isArray(res?.list)) out.push(...(res.list as ListRow[]).filter((x): x is ListRow => x != null))
+    const rows = (res as { rows?: unknown } | null)?.rows
+    if (Array.isArray(rows)) out.push(...(rows as ListRow[]).filter((x): x is ListRow => x != null))
   }
   return out
+}
+
+/**
+ * The nested maps a v5 row carries alongside its materialized columns. OpenTelemetry
+ * attributes are stored by type and by scope, so `service.name` (a RESOURCE attribute)
+ * is at `data.resources_string['service.name']`, an HTTP status at
+ * `data.attributes_string['http.response.status_code']`, and so on.
+ */
+const ROW_ATTRIBUTE_MAPS = ['resources_string', 'attributes_string', 'attributes_number', 'attributes_bool', 'scope_string'] as const
+
+/**
+ * Flatten one v5 row's `data` into the single lookup map the normalizers read: the
+ * nested attribute maps first, then the top-level columns OVER them — a materialized
+ * column is the authoritative value when both carry the same name.
+ */
+function flatRow(data: Record<string, unknown> | null | undefined): Record<string, unknown> {
+  if (!data) return {}
+  const flat: Record<string, unknown> = {}
+  for (const m of ROW_ATTRIBUTE_MAPS) {
+    const bag = data[m]
+    if (bag && typeof bag === 'object' && !Array.isArray(bag)) Object.assign(flat, bag)
+  }
+  return Object.assign(flat, data)
 }
 
 /** Read the first present key from a flattened O11y row `data` map. */
@@ -677,9 +671,11 @@ export function toIso(ts: string | number | undefined | null): string {
 /** One application/platform log line, projected from a logs list row. */
 export type LogRow = { id: string; timestamp: string; severity: string; service: string; body: string }
 
-/** Normalize one logs list row → LogRow (tolerant of column-name variants). */
+/** Normalize one logs row → LogRow (tolerant of column-name variants). `service` comes
+ *  from the `service.name` RESOURCE attribute, which `flatRow` lifts out of
+ *  `resources_string`; a row that carries none leaves it empty rather than guessing. */
 export function normalizeLogRow(row: ListRow, idx: number): LogRow {
-  const d = row.data ?? {}
+  const d = flatRow(row.data)
   return {
     id: pick(d, ['id', 'log_id']) || `${str(row.timestamp)}-${idx}`,
     timestamp: toIso(row.timestamp) || toIso(pick(d, ['timestamp'])),
@@ -694,7 +690,7 @@ export function normalizeLogs(body: unknown): LogRow[] {
   return parseListRows(body).map(normalizeLogRow)
 }
 
-/** One trace/span row from a `dataSource: traces` list query. */
+/** One trace/span row from a `signal: traces` raw query. */
 export type TraceSpan = {
   id: string
   timestamp: string
@@ -706,12 +702,12 @@ export type TraceSpan = {
   status: string
 }
 
-/** Normalize one traces list row → TraceSpan. */
+/** Normalize one traces row → TraceSpan. */
 export function normalizeTraceSpan(row: ListRow, idx: number): TraceSpan {
-  const d = row.data ?? {}
+  const d = flatRow(row.data)
   const traceId = pick(d, ['traceID', 'traceId', 'trace_id'])
   const spanId = pick(d, ['spanID', 'spanId', 'span_id'])
-  const durRaw = d?.['durationNano'] ?? d?.['duration_nano'] ?? d?.['durationNs']
+  const durRaw = d['durationNano'] ?? d['duration_nano'] ?? d['durationNs']
   const durNum = Number(durRaw)
   return {
     id: spanId || traceId || `${str(row.timestamp)}-${idx}`,
@@ -734,12 +730,15 @@ export function normalizeSpans(body: unknown): TraceSpan[] {
 const u = (path: string): string => cloudProxyV1Url(`o11y/${path}`)
 
 // The composite builder query rides the FLAT public path `/v1/o11y/query_range` (one
-// /v1/, no nested /api/vN). `listQueryPayload` + `parseListRows` are a matched v3 pair
-// (`compositeQuery.{queryType,builderQueries}` → `data.result[].list`); the cloud
-// clients/o11y flat route (query.go) resolves this flat path to the v3 engine handler
-// SERVER-SIDE. (The upstream module's version-less alias would instead resolve to the
-// HIGHEST engine version (v5), whose composite accepts only `{queries:[…]}` and 400s
-// the v3 shape — which is exactly why the mapping is pinned in cloud, not here.)
+// /v1/, no nested /api/vN). `listQueryPayload` + `parseListRows` are a matched v5 pair:
+// `compositeQuery.{queries:[{type,spec}]}` out, `data.data.results[].rows[]` back.
+//
+// This used to say that cloud's clients/o11y flat route (query.go) pinned the path to
+// the v3 engine handler server-side, so a v3 body was safe here. That file was DELETED
+// from cloud. The version-less path now resolves to the HIGHEST engine version, v5,
+// whose composite accepts only `{queries:[…]}` — so the v3 body this client kept sending
+// was 400'd on every Logs and Traces load, and the comment was the reason nobody looked.
+// The path was never the problem; the dialect was.
 const COMPOSITE_QUERY_RANGE = 'query_range'
 
 /** The APM POST body — a start/end window + optional tags filter (O11y shape). */
@@ -782,18 +781,31 @@ export const ApmApi = {
   dashboards: async (): Promise<Dashboard[]> => normalizeDashboards(await restGet<unknown>(u('dashboards'))),
   dashboard: (uuid: string): Promise<unknown> => restGet<unknown>(u(`dashboards/${encodeURIComponent(uuid)}`)),
 
-  // ── Logs + Traces (composite query_range; `/v1/o11y/logs` is a stub) ──
+  // ── Logs + Traces (composite query_range) ──
+  // These POST `/v1/o11y/query_range`, NOT `/v1/o11y/logs` — that route is GET-only and
+  // 405s a POST, so an error card blaming it sends the next reader to the wrong door.
+  //
   // A `service` scopes the query to ONE product's OTel `service.name` (the per-product
   // Logs sub-page); omit it for the org-wide stream. The rows are re-filtered client-side
-  // to the same service so a runtime ignoring the item can never leak other services' lines.
+  // to the same service, so a runtime that ignored the filter still cannot leak another
+  // service's lines onto a per-product page.
+  //
+  // MEASURED SERVER DEFECT (prod api.hanzo.ai, o11y v1.5.58): the scoped query answers
+  // 500 `failed to get logs keys`, and so does anything else carrying `filter`, `order`
+  // or `selectFields`. The o11y module resolves field keys against the databases
+  // `o11y_metadata` / `o11y_metrics`, and neither EXISTS on the deployed datastore —
+  // only `event` does, with the log rows in `event.log`. ClickHouse's own query log
+  // confirms it. The unfiltered `raw` query over the same window returns real rows (5M
+  // scanned), so the dialect and the transport are fine; the store is missing two
+  // databases. It unblocks when those exist, or when the module is pointed at `event`.
+  // Nothing here compensates for it: the correct query goes out, and a failure surfaces
+  // as an honest error card naming /v1/o11y/query_range.
   logs: async (w: ApmWindow, limit = 200, service?: string): Promise<LogRow[]> => {
-    const filters = service ? [serviceFilterItem('logs', service)] : []
-    const rows = normalizeLogs(await restPost<unknown>(u(COMPOSITE_QUERY_RANGE), listQueryPayload('logs', w, limit, filters)))
+    const rows = normalizeLogs(await restPost<unknown>(u(COMPOSITE_QUERY_RANGE), listQueryPayload('logs', w, limit, service)))
     return service ? rows.filter((r) => !r.service || r.service === service) : rows
   },
   traceSearch: async (w: ApmWindow, limit = 200, service?: string): Promise<TraceSpan[]> => {
-    const filters = service ? [serviceFilterItem('traces', service)] : []
-    const rows = normalizeSpans(await restPost<unknown>(u(COMPOSITE_QUERY_RANGE), listQueryPayload('traces', w, limit, filters)))
+    const rows = normalizeSpans(await restPost<unknown>(u(COMPOSITE_QUERY_RANGE), listQueryPayload('traces', w, limit, service)))
     return service ? rows.filter((r) => !r.service || r.service === service) : rows
   },
 

--- a/src/lib/api/client.ts
+++ b/src/lib/api/client.ts
@@ -40,12 +40,39 @@ export const envelopeTotal = (env: { total?: unknown; data2?: unknown }, rows: u
   return Array.isArray(rows) ? rows.length : 0
 }
 
+/**
+ * The origin-less form of a request URL — `https://console.hanzo.ai/v1/o11y/query_range`
+ * and `/v1/o11y/query_range` both become `/v1/o11y/query_range`. ONE form, so an error
+ * card names the same endpoint in the browser (absolute) and on the server (relative).
+ * The query string is dropped: this labels the endpoint, not the individual call.
+ */
+const endpointPath = (url: string): string => {
+  if (url === '') return ''
+  try {
+    return new URL(url, 'http://_').pathname
+  } catch {
+    return url
+  }
+}
+
 export class ApiError extends Error {
   readonly status: number
-  constructor(message: string, status = 0) {
+  /**
+   * The request path this failure actually came from (`/v1/o11y/query_range`), or ''
+   * when the thrower had no URL to name.
+   *
+   * It is here because the honest-error cards were naming the endpoint they were LABELED
+   * with rather than the one that failed: the Logs card said `/v1/o11y/logs` — a route
+   * that is GET-only and 405s a POST — for a failure at `/v1/o11y/query_range`, and cost
+   * a debugging session at the wrong door. A card can only tell the truth about which
+   * call broke if the error carries it, so every throw below stamps its own URL.
+   */
+  readonly endpoint: string
+  constructor(message: string, status = 0, endpoint = '') {
     super(message)
     this.name = 'ApiError'
     this.status = status
+    this.endpoint = endpointPath(endpoint)
   }
 }
 
@@ -271,18 +298,18 @@ async function request<T>(
       body: opts.body !== undefined ? JSON.stringify(opts.body) : undefined,
     })
   } catch (e) {
-    throw new ApiError(e instanceof Error ? e.message : 'Network request failed')
+    throw new ApiError(e instanceof Error ? e.message : 'Network request failed', 0, url)
   }
 
   if (res.status === 401 || res.status === 403) {
-    throw new ApiError('Not authorized', res.status)
+    throw new ApiError('Not authorized', res.status, url)
   }
 
   let json: ApiResponse<T>
   try {
     json = (await res.json()) as ApiResponse<T>
   } catch {
-    throw new ApiError(`Invalid response from server (HTTP ${res.status})`, res.status)
+    throw new ApiError(`Invalid response from server (HTTP ${res.status})`, res.status, url)
   }
 
   if (!res.ok && json?.status !== 'ok') {
@@ -294,15 +321,19 @@ async function request<T>(
     // sending a planless org to buy credits that will not satisfy the gate.
     const alt = (json as { error?: unknown })?.error
     const reason = json?.msg || (typeof alt === 'string' ? alt : '')
-    throw new ApiError(reason || `Request failed (HTTP ${res.status})`, res.status)
+    throw new ApiError(reason || `Request failed (HTTP ${res.status})`, res.status, url)
   }
+  // The envelope's own verdict, checked HERE rather than re-checked identically by all
+  // seventeen verbs below. It was duplicated at every one of them, and every copy threw
+  // an ApiError that could not name its endpoint because the URL is built in here. One
+  // place, one throw, and the path comes with it. HTTP was 2xx, so the status stays 0.
+  if (json?.status !== 'ok') throw new ApiError(json?.msg || 'Request failed', 0, url)
   return json
 }
 
 /** GET that unwraps `data` and throws on a non-ok envelope. */
 export async function get<T>(path: string, query?: Query): Promise<T> {
   const r = await request<T>('GET', path, { query })
-  if (r.status !== 'ok') throw new ApiError(r.msg || 'Request failed')
   return r.data
 }
 
@@ -325,11 +356,12 @@ export async function get<T>(path: string, query?: Query): Promise<T> {
 export async function postForm<T>(path: string, form: FormData): Promise<T> {
   const headers = { ...baseHeaders(false) }
   delete (headers as Record<string, string>)['Content-Type']
+  const url = buildUrl(path)
   let res: Response
   try {
-    res = await authedFetch(buildUrl(path), { method: 'POST', credentials: 'include', headers, body: form })
+    res = await authedFetch(url, { method: 'POST', credentials: 'include', headers, body: form })
   } catch (e) {
-    throw new ApiError(e instanceof Error ? e.message : 'Network request failed')
+    throw new ApiError(e instanceof Error ? e.message : 'Network request failed', 0, url)
   }
   const body = (await res.json().catch(() => null)) as
     | (T & { error?: unknown; message?: unknown })
@@ -338,9 +370,9 @@ export async function postForm<T>(path: string, form: FormData): Promise<T> {
     const reason = [body?.error, body?.message].find((v) => typeof v === 'string' && v) as
       | string
       | undefined
-    throw new ApiError(reason || `Request failed (HTTP ${res.status})`, res.status)
+    throw new ApiError(reason || `Request failed (HTTP ${res.status})`, res.status, url)
   }
-  if (!body) throw new ApiError(`Invalid response from server (HTTP ${res.status})`, res.status)
+  if (!body) throw new ApiError(`Invalid response from server (HTTP ${res.status})`, res.status, url)
   return body as T
 }
 
@@ -354,7 +386,6 @@ export async function postForm<T>(path: string, form: FormData): Promise<T> {
  */
 export async function originGet<T>(path: string, query?: Query): Promise<T> {
   const r = await request<T>('GET', path, { query, absoluteUrl: originV1Url(path) })
-  if (r.status !== 'ok') throw new ApiError(r.msg || 'Request failed')
   return r.data
 }
 
@@ -370,7 +401,6 @@ export async function originGet<T>(path: string, query?: Query): Promise<T> {
  */
 export async function originPost<T>(path: string, body?: unknown, query?: Query, headers?: Record<string, string>): Promise<T> {
   const r = await request<T>('POST', path, { query, body, absoluteUrl: originV1Url(path), headers })
-  if (r.status !== 'ok') throw new ApiError(r.msg || 'Request failed')
   return r.data
 }
 
@@ -386,13 +416,11 @@ export async function originPost<T>(path: string, body?: unknown, query?: Query,
  */
 export async function originPut<T>(path: string, body?: unknown, query?: Query): Promise<T> {
   const r = await request<T>('PUT', path, { query, body, absoluteUrl: originV1Url(path) })
-  if (r.status !== 'ok') throw new ApiError(r.msg || 'Request failed')
   return r.data
 }
 
 export async function originPatch<T>(path: string, body?: unknown, query?: Query): Promise<T> {
   const r = await request<T>('PATCH', path, { query, body, absoluteUrl: originV1Url(path) })
-  if (r.status !== 'ok') throw new ApiError(r.msg || 'Request failed')
   return r.data
 }
 
@@ -401,7 +429,6 @@ export async function originPatch<T>(path: string, body?: unknown, query?: Query
  *  so every existing `await originDelete(...)` caller is unchanged. */
 export async function originDelete<T = void>(path: string, query?: Query): Promise<T> {
   const r = await request<T>('DELETE', path, { query, absoluteUrl: originV1Url(path) })
-  if (r.status !== 'ok') throw new ApiError(r.msg || 'Request failed')
   return r.data
 }
 
@@ -417,28 +444,24 @@ export async function originDelete<T = void>(path: string, query?: Query): Promi
  */
 export async function cloudGet<T>(path: string, query?: Query): Promise<T> {
   const r = await request<T>('GET', path, { query, absoluteUrl: cloudProxyV1Url(path) })
-  if (r.status !== 'ok') throw new ApiError(r.msg || 'Request failed')
   return r.data
 }
 
 /** Envelope POST routed through the same-origin `/v1` user-bearer BFF — the mutating twin of `cloudGet`. */
 export async function cloudPost<T = string>(path: string, body?: unknown, query?: Query): Promise<ApiResponse<T>> {
   const r = await request<T>('POST', path, { query, body, absoluteUrl: cloudProxyV1Url(path) })
-  if (r.status !== 'ok') throw new ApiError(r.msg || 'Request failed')
   return r
 }
 
 /** GET that returns the full envelope (for list endpoints needing the total). */
 export async function getList<T>(path: string, query?: Query): Promise<{ rows: T; total: number }> {
   const r = await request<T>('GET', path, { query })
-  if (r.status !== 'ok') throw new ApiError(r.msg || 'Request failed')
   return { rows: r.data, total: envelopeTotal(r, r.data) }
 }
 
 /** POST a JSON body; returns the `msg` (most mutations return ok/affected). */
 export async function post<T = string>(path: string, body?: unknown, query?: Query): Promise<ApiResponse<T>> {
   const r = await request<T>('POST', path, { query, body })
-  if (r.status !== 'ok') throw new ApiError(r.msg || 'Request failed')
   return r
 }
 
@@ -452,14 +475,12 @@ export async function post<T = string>(path: string, body?: unknown, query?: Que
  */
 export async function iamList<T>(segment: string, query?: Query): Promise<{ rows: T[]; total: number }> {
   const r = await request<T[]>('GET', `iam/${segment}`, { query })
-  if (r.status !== 'ok') throw new ApiError(r.msg || 'Request failed')
   const rows = Array.isArray(r.data) ? r.data : []
   return { rows, total: envelopeTotal(r, rows) }
 }
 
 export async function iamOne<T>(segment: string, query?: Query): Promise<T> {
   const r = await request<T>('GET', `iam/${segment}`, { query })
-  if (r.status !== 'ok') throw new ApiError(r.msg || 'Request failed')
   if (r.data === undefined || r.data === null) throw new ApiError('Not found', 404)
   return r.data
 }
@@ -484,27 +505,23 @@ export const memberOf = (collection: string, owner: string, name: string): strin
 /** PATCH a JSON body — the update verb for a resource member. */
 export async function patch<T = string>(path: string, body?: unknown, query?: Query): Promise<ApiResponse<T>> {
   const r = await request<T>('PATCH', path, { query, body })
-  if (r.status !== 'ok') throw new ApiError(r.msg || 'Request failed')
   return r
 }
 
 /** DELETE a resource member. */
 export async function del<T = string>(path: string, query?: Query): Promise<ApiResponse<T>> {
   const r = await request<T>('DELETE', path, { query })
-  if (r.status !== 'ok') throw new ApiError(r.msg || 'Request failed')
   return r
 }
 
 /** The `cloudGet` twins for the mutating member verbs. */
 export async function cloudPatch<T = string>(path: string, body?: unknown, query?: Query): Promise<ApiResponse<T>> {
   const r = await request<T>('PATCH', path, { query, body, absoluteUrl: cloudProxyV1Url(path) })
-  if (r.status !== 'ok') throw new ApiError(r.msg || 'Request failed')
   return r
 }
 
 export async function cloudDelete<T = string>(path: string, query?: Query): Promise<ApiResponse<T>> {
   const r = await request<T>('DELETE', path, { query, absoluteUrl: cloudProxyV1Url(path) })
-  if (r.status !== 'ok') throw new ApiError(r.msg || 'Request failed')
   return r
 }
 
@@ -621,17 +638,20 @@ async function restRequest<T>(
       body: body !== undefined ? JSON.stringify(body) : undefined,
     })
   } catch (e) {
-    throw new ApiError(e instanceof Error ? e.message : 'Network request failed')
+    throw new ApiError(e instanceof Error ? e.message : 'Network request failed', 0, url)
   }
 
-  return parseRestResponse<T>(res)
+  return parseRestResponse<T>(res, url)
 }
 
 /** Parse a plain-REST `Response` into `T | undefined`: 401/403 → ApiError, 204 → undefined,
  *  a JSON body unwrapped, and a non-ok status carrying the human message from whichever
- *  error shape (`{msg}` / `{error}` / `{error:{message}}`). Shared by every REST verb. */
-async function parseRestResponse<T>(res: Response): Promise<T | undefined> {
-  if (res.status === 401 || res.status === 403) throw new ApiError('Not authorized', res.status)
+ *  error shape (`{msg}` / `{error}` / `{error:{message}}`). Shared by every REST verb.
+ *  `url` is the request's own URL, stamped onto every failure so the error names the
+ *  endpoint that actually broke — `res.url` is empty on a constructed Response, so the
+ *  caller passes what it asked for rather than what the Response remembers. */
+async function parseRestResponse<T>(res: Response, url: string): Promise<T | undefined> {
+  if (res.status === 401 || res.status === 403) throw new ApiError('Not authorized', res.status, url)
   if (res.status === 204) return undefined
 
   const text = await res.text()
@@ -643,8 +663,8 @@ async function parseRestResponse<T>(res: Response): Promise<T | undefined> {
       // A non-JSON error body IS the human message — a backend that answers a 4xx with a
       // plain-text reason (the engine's 400/404/409) — so surface it (capped) instead of a
       // generic code. A non-JSON 2xx body is a malformed success.
-      if (!res.ok) throw new ApiError(text.trim().slice(0, 300) || `Request failed (HTTP ${res.status})`, res.status)
-      throw new ApiError(`Invalid response from server (HTTP ${res.status})`, res.status)
+      if (!res.ok) throw new ApiError(text.trim().slice(0, 300) || `Request failed (HTTP ${res.status})`, res.status, url)
+      throw new ApiError(`Invalid response from server (HTTP ${res.status})`, res.status, url)
     }
   }
 
@@ -662,7 +682,7 @@ async function parseRestResponse<T>(res: Response): Promise<T | undefined> {
         if (typeof em === 'string') m = em
       }
     }
-    throw new ApiError(m || `Request failed (HTTP ${res.status})`, res.status)
+    throw new ApiError(m || `Request failed (HTTP ${res.status})`, res.status, url)
   }
   return json as T
 }
@@ -692,9 +712,9 @@ export const restPostRaw = <T>(
         body: body as BodyInit,
       })
     } catch (e) {
-      throw new ApiError(e instanceof Error ? e.message : 'Network request failed')
+      throw new ApiError(e instanceof Error ? e.message : 'Network request failed', 0, url)
     }
-    return parseRestResponse<T>(res)
+    return parseRestResponse<T>(res, url)
   })()
 
 /** REST GET on a full URL (build it with `v1Url`). */

--- a/src/lib/api/error-endpoint.test.ts
+++ b/src/lib/api/error-endpoint.test.ts
@@ -1,0 +1,86 @@
+/**
+ * `ApiError.endpoint` — the failure names the call that actually failed.
+ *
+ * The honest-error cards (`RuntimeNotice` and friends) print an endpoint so a reader can
+ * go look at it. They used to SYNTHESIZE it from a display label: the Logs card was
+ * rendered as `surface="logs"` and printed `/v1/o11y/logs`, while the request that failed
+ * was `POST /v1/o11y/query_range`. `/v1/o11y/logs` is a real route — GET-only, 405 on a
+ * POST — so the wrong answer looked like a lead and someone spent real time on it.
+ *
+ * The fix is that the error carries its own URL, so these tests run the REAL client
+ * (only `fetch` is stubbed) and assert the path off the thrown `ApiError`. A label can be
+ * anything; this is the address.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+
+import { ApiError, restGet, restPost, cloudProxyV1Url } from './client'
+import { ApmApi, apmWindow } from './apm'
+
+const ORIGIN = 'https://console.hanzo.ai'
+
+/** The ApiError a rejected call threw. Fails loudly when the call RESOLVED — a test that
+ *  caught nothing must never read as a pass. */
+async function thrownBy(call: () => Promise<unknown>): Promise<ApiError> {
+  try {
+    await call()
+  } catch (e) {
+    expect(e, 'the failure must be a typed ApiError').toBeInstanceOf(ApiError)
+    return e as ApiError
+  }
+  throw new Error('the call resolved — no error was thrown, so there is nothing to assert')
+}
+
+describe('ApiError.endpoint (the path that actually failed)', () => {
+  const sent: string[] = []
+  let reply: () => Response
+
+  beforeEach(() => {
+    sent.length = 0
+    reply = () => new Response('{"error":"boom"}', { status: 500, headers: { 'content-type': 'application/json' } })
+    ;(globalThis as { window?: unknown }).window = { location: { origin: ORIGIN, hostname: 'console.hanzo.ai' } }
+    vi.stubGlobal('fetch', (url: string) => {
+      sent.push(String(url))
+      return Promise.resolve(reply())
+    })
+  })
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    delete (globalThis as { window?: unknown }).window
+  })
+
+  it('a failed o11y logs read names /v1/o11y/query_range — NOT the /v1/o11y/logs label', async () => {
+    const e = await thrownBy(() => ApmApi.logs(apmWindow(3600), 50))
+    expect(sent, 'the request must have gone out for its URL to be meaningful').toEqual([`${ORIGIN}/v1/o11y/query_range`])
+    expect(e.endpoint).toBe('/v1/o11y/query_range')
+    expect(e.endpoint).not.toBe('/v1/o11y/logs')
+    expect(e.status).toBe(500)
+  })
+
+  it('carries the path on every plain-REST failure class: 5xx, 401/403, and a network error', async () => {
+    const url = cloudProxyV1Url('o11y/services')
+
+    expect((await thrownBy(() => restPost(url, {}))).endpoint).toBe('/v1/o11y/services')
+
+    reply = () => new Response('nope', { status: 403 })
+    const denied = await thrownBy(() => restGet(url))
+    expect(denied.status).toBe(403)
+    expect(denied.endpoint).toBe('/v1/o11y/services')
+
+    vi.stubGlobal('fetch', () => Promise.reject(new Error('connection refused')))
+    const offline = await thrownBy(() => restPost(url, {}))
+    expect(offline.message).toBe('connection refused')
+    expect(offline.endpoint).toBe('/v1/o11y/services')
+  })
+
+  it('normalizes to ONE origin-less form, so the card reads the same in the browser and on the server', () => {
+    expect(new ApiError('x', 500, `${ORIGIN}/v1/o11y/query_range`).endpoint).toBe('/v1/o11y/query_range')
+    expect(new ApiError('x', 500, '/v1/o11y/query_range').endpoint).toBe('/v1/o11y/query_range')
+    // The query string labels a single call, not the endpoint — dropped.
+    expect(new ApiError('x', 500, `${ORIGIN}/v1/platform/fleet?env=main`).endpoint).toBe('/v1/platform/fleet')
+  })
+
+  it('is empty — never guessed — when the thrower had no URL to name', () => {
+    expect(new ApiError('boom').endpoint).toBe('')
+    expect(new ApiError('boom', 404).endpoint).toBe('')
+  })
+})

--- a/src/lib/api/iam-paas-embed.test.ts
+++ b/src/lib/api/iam-paas-embed.test.ts
@@ -8,8 +8,13 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
  * index (HTTP 200 HTML) for any NON-`/v1/` path. The OrgSwitcher hit `/admin/iam/*`
  * and Status hit `/paas/*` — both non-`/v1/`, so they parsed the SPA and errored
  * ("Invalid response from server (HTTP 200)" → empty switcher / "Could not reach the
- * platform"). In the embed these MUST address cloud-native `/v1/iam/*` and
- * `/v1/paas/*` (which the cloud binary serves) with the bearer.
+ * platform"). In the embed these MUST address cloud-native `/v1/*` (which the cloud
+ * binary serves) with the bearer.
+ *
+ * The Status inventory has since moved again, and further than a prefix: cloud folded
+ * `paas` into `platform` and retired the duplicate head, so `/v1/paas/apps` is a bare
+ * 404 and the fleet board lives at `/v1/platform/fleet`. That is what this pins now —
+ * same guard, current address.
  *
  * IS_EMBED is captured at module load, so it is mocked BEFORE importing the clients.
  */
@@ -54,12 +59,14 @@ describe('go:embed IAM-admin + PaaS address cloud-native /v1/* (not the pruned B
     expect(fetched[0].url).not.toContain('/admin/iam/')
   })
 
-  it('Observe→Status apps inventory → GET <origin>/v1/paas/apps (was /paas/apps → SPA 200)', async () => {
+  it('Observe→Status apps inventory → GET <origin>/v1/platform/fleet (was /v1/paas/apps → 404)', async () => {
     const { PlatformApi } = await import('./platform')
     await PlatformApi.apps()
     expect(fetched).toHaveLength(1)
     expect(fetched[0].method).toBe('GET')
-    expect(fetched[0].url).toBe(`${ORIGIN}/v1/paas/apps`)
+    expect(fetched[0].url).toBe(`${ORIGIN}/v1/platform/fleet`)
+    // The retired head must not come back: `/v1/paas/*` answers 404, not an inventory.
+    expect(fetched[0].url).not.toContain('/paas')
   })
 
   it('an IAM-admin mutation also rides the cloud-native /v1/iam surface', async () => {

--- a/src/lib/api/index.ts
+++ b/src/lib/api/index.ts
@@ -306,7 +306,7 @@ export {
   type OccurrenceFrame,
   type IssuesQuery,
   type Dashboard,
-  type O11yDataSource,
+  type O11ySignal,
   type LogRow,
   type TraceSpan,
 } from './apm'

--- a/src/lib/api/platform.ts
+++ b/src/lib/api/platform.ts
@@ -1,29 +1,23 @@
 /**
  * Platform API — Hanzo cluster inventory + PaaS control plane.
  *
- * TWO transports, cleanly split by authority:
- *   - Cluster INVENTORY + node-pool lifecycle (list / get / add-pool / scale-pool /
- *     delete-pool) go through the unified cloud binary at `/v1/clusters*`, via the
- *     same-origin user-bearer `/v1` proxy (app/v1/[...path]/route.ts → cloud-api,
- *     org resolved from the Bearer owner). This is the native, per-org surface every
- *     cluster consumer reads — one source of truth.
- *   - The apps inventory and cluster PROVISIONING (spin up a whole new DOKS cluster)
- *     stay on the `/paas` control plane (app/paas/[...path]/route.ts), which injects the
- *     platform SERVICE token from server-only env (KMS) and is brand-admin gated — the
- *     right authority for a god-mode, multi-tenant operation. When the token is unset the
- *     proxy returns an honest 501 the UI renders as "not configured"; nothing is fabricated.
+ * ONE transport: everything here goes through the unified cloud binary over the
+ * same-origin user-bearer `/v1` proxy (app/v1/[...path]/route.ts → cloud-api, org
+ * resolved from the Bearer owner). The apps inventory used to be the exception — it rode
+ * the `/paas` control plane and its god-mode platform SERVICE token — but cloud folded
+ * `paas` into `platform` and retired the duplicate head, and the fleet read is per-org
+ * anyway, so it joins the rest on the bearer path. See `fleetUrl`.
  *
  * REAL surfaces:
- *   - GET /v1/apps                 → the apps inventory (Status + Kubernetes modules).
+ *   - GET /v1/platform/fleet       → the apps inventory (Status + Kubernetes modules).
  *   - GET /v1/clusters[/:id]       → the org's DEDICATED Hanzo K8S (DOKS) clusters, with
  *     their node pools. Honest empty when the org has none (shared Hanzo Cloud is default).
  *   - POST   /v1/clusters/:cid/pools            → add a node pool.
  *   - POST   /v1/clusters/:cid/pools/:pid/scale → scale a pool's node count.
  *   - DELETE /v1/clusters/:cid/pools/:pid       → remove a node pool.
- *   - POST /v1/org/{org}/cluster   → provision a fresh dedicated cluster (`/paas`).
+ *   - POST /v1/org/{org}/cluster   → provision a fresh dedicated cluster.
  */
 import { restGet, restPost, restDelete, cloudProxyV1Url } from './client'
-import { IS_EMBED } from '~/lib/embed'
 
 /** Where a cluster lives: shared multi-tenant Hanzo Cloud, or a BYO/managed DOKS. */
 export type ClusterKind = 'shared' | 'byo' | (string & {})
@@ -167,24 +161,23 @@ export type AppsQuery = {
 }
 
 /**
- * Same-origin PaaS inventory path, split by DEPLOYMENT topology:
- *  - STANDALONE console (console2/admin.hanzo.ai): the `/paas/*` server proxy, which
- *    injects the platform SERVICE token (KMS) and is brand-admin gated.
- *  - go:embed console (IS_EMBED, console.hanzo.ai / cloud.hanzo.ai): the static export
- *    has NO server routes — `/paas/*` is pruned and cloud's catch-all serves the SPA
- *    index (HTTP 200 HTML) for any non-`/v1/` path, so the old `/paas` client parsed the
- *    SPA and errored "Invalid response from server (HTTP 200)" → "Could not reach the
- *    platform" (the broken Observe→Status). Cloud serves the SAME fleet inventory
- *    natively at `/v1/paas/<path>` (bearer-scoped from the validated principal), so in
- *    the embed we address it directly. The `/v1` BFF deliberately EXCLUDES `paas/*`
- *    (proxy-allow.ts), which is why this is embed-gated rather than unconditional.
+ * The apps inventory — the operator FLEET board — at `/v1/platform/fleet`.
+ *
+ * `paas` was a second name for `platform`: the same per-org control plane, reachable
+ * under two heads. Cloud folded it into one and retired the duplicate, so
+ * `/v1/paas/apps` now answers a bare 404 and `/v1/platform/fleet` answers the inventory
+ * — `{apps, summary}`, the same rows this reader already unwraps. One product, one name.
+ *
+ * The path is unconditional now, where the old `/paas` reader was split by deployment
+ * topology (the embed addressed cloud natively, the standalone went through the
+ * brand-admin `/paas` proxy and its platform SERVICE token). That split is gone for
+ * this read, and both halves of it are better off:
+ *  - `platform` IS allow-listed on the `/v1` bearer BFF (proxy-allow.ts), so the
+ *    standalone console reaches it as the signed-in user — no god-mode service token
+ *    for what is a plain per-org read. Cloud's SanitizeIdentity scopes the fleet to the
+ *    Bearer owner, which is the scoping we wanted anyway.
+ *  - the embed already spoke `/v1/*` natively, and still does.
  */
-const url = (path: string) =>
-  IS_EMBED
-    ? cloudProxyV1Url(`paas/${path.replace(/^\/+/, '')}`)
-    : `/paas/${path.replace(/^\/+/, '')}`
-const enc = encodeURIComponent
-
 const qs = (q: AppsQuery): string => {
   const p = new URLSearchParams()
   if (q.org) p.set('org', q.org)
@@ -194,6 +187,9 @@ const qs = (q: AppsQuery): string => {
   const s = p.toString()
   return s ? `?${s}` : ''
 }
+
+const fleetUrl = (query: AppsQuery): string => cloudProxyV1Url(`platform/fleet${qs(query)}`)
+const enc = encodeURIComponent
 
 /** Pull a `Cluster[]` from `{clusters:[…]}`, `{data:[…]}`, or a bare array (defensive). */
 const clustersOf = (payload: unknown): Cluster[] => {
@@ -211,9 +207,10 @@ const clustersOf = (payload: unknown): Cluster[] => {
 const clustersUrl = (path = ''): string => cloudProxyV1Url(`clusters${path}`)
 
 export const PlatformApi = {
-  /** The apps inventory — the real "what is running" board across all clusters (`/paas`). */
+  /** The apps inventory — the real "what is running" board across all clusters
+   *  (`GET /v1/platform/fleet` → `{apps, summary}`; see `fleetUrl`). */
   apps: async (query: AppsQuery = {}): Promise<PlatformApp[]> => {
-    const r = await restGet<{ apps?: PlatformApp[] }>(url(`apps${qs(query)}`))
+    const r = await restGet<{ apps?: PlatformApp[] }>(fleetUrl(query))
     return r?.apps ?? []
   },
 


### PR DESCRIPTION
Companion to **hanzo-inc/cloud#387**. The three cards on `/models` were dark for **three unrelated reasons**; two are fixed here, the third (Metrics) is the cloud PR.

Everything below was measured against the live API with a valid bearer token. The unauthenticated `403`s were masking the real errors — with a token the same routes return `500`, `400` and `502`, which is where the actual bugs are.

## 1. STATUS asked a retired head

```
GET /v1/paas/apps      -> 404 "404 page not found"
GET /v1/platform/fleet -> 200 {"apps":[],"summary":{...}}
```

`paas` was a second name for `platform` — the same per-org control plane at two prefixes — and cloud folded it into `/v1/platform/fleet`. The console's own `proxy-allow.ts` already documents the fold; only the client never got the message.

`url()` had exactly one caller, so repointing it *is* the surgical change. I dropped the `IS_EMBED` split rather than preserving it: the non-embed branch forwarded to `${API}/v1/paas/${path}` — the same 404 head — so keeping it would have left the standalone console broken. Both halves now ride the `/v1` bearer BFF, which also drops the brand-admin platform SERVICE token in favour of a per-org bearer read.

The test that froze the old path is **repointed, not deleted**, plus `expect(url).not.toContain('/paas')` so the retired head cannot creep back.

## 2. LOGS spoke v3 at a v5 server

The console POSTs to `/v1/o11y/query_range` — **not** `/v1/o11y/logs`, which is GET-only and 405s on POST. cloud deleted the route that pinned that path to the v3 engine; the module's v5 querier took the address, and v5's `CompositeQuery` accepts exactly one field, `queries`:

```
v3 body -> 400 invalid body: unknown field "queryType" in composite query
           (remove it and it rejects "panelType", then "builderQueries")
```

The builder now emits the v5 envelope. `serviceFilterItem` → `serviceFilterExpression` (v5 filters are an expression, so the client stops needing to know whether `service.name` is a resource attribute or a column). `selectFields` is deleted along with the v3 workaround that required it. `parseListRows` reads **only** the v5 location — the v3 paths are gone, not tolerated. A new `flatRow()` folds the row's attribute maps so `service.name` reaches `LogRow.service`; a row without one gets `''` rather than an invented value.

**Verified end-to-end against production** — the exact body this builder emits:

```
POST /v1/o11y/query_range  {"schemaVersion":"v1","requestType":"raw",
  "compositeQuery":{"queries":[{"type":"builder_query",
    "spec":{"name":"A","signal":"logs","limit":200,"offset":0}}]}}
-> 200, 200 real rows at data.data.results[].rows[]
   row keys: attributes_bool, attributes_number, attributes_string, body, id,
             resources_string, scope_name, scope_string
```

i.e. exactly the path `parseListRows` reads and exactly the keys `flatRow` folds.

## 3. The card named the wrong endpoint

`endpoint · /v1/o11y/{surface}` was synthesized from a **display prop**, so a failure at `/v1/o11y/query_range` was reported against `/v1/o11y/logs` — a route that is GET-only and looks perfectly healthy when you go and check it by hand. That diagnostic costs an hour every time it fires; it cost one here.

`ApiError` now carries the real endpoint (normalized to one origin-less form) and the card renders it. With no path it renders no path, rather than a guess.

Two things that were required rather than tidy:
- The `status !== 'ok'` throw was duplicated at **16** call sites and none could name an endpoint, because the URL is built inside `request()`. Moved in — 16 lines deleted, 1 added, message and status preserved.
- `parseRestResponse` takes the URL as a **parameter** rather than reading `res.url`. A constructed `Response` has `url === ''`, so reading it would have produced empty endpoints under every mocked test while looking correct.

## 4. A test that asserted nothing

`apm.test.ts` asserted `compositeQuery.queryType === 'builder'` against the pure builder function — a tautology. It asserted that the builder builds what the builder is written to build, its describe block was literally named *"O11y v3 query_range LIST"*, and it passed for the entire time production was 400ing.

The replacement pins the **server's** contract: request types, query types, composite fields and the retired v3 key set transcribed from `o11y v1.5.58` and **deliberately not imported from `./apm`** — importing them rebuilds the same tautology one level up. It runs over the serialized wire (`JSON.parse(JSON.stringify(...))`, where `undefined` keys vanish) across org-wide × scoped × logs × traces.

Guards so it cannot pass by inspecting nothing:
```
expect(cases.length,   'no payloads under test — this asserts nothing').toBeGreaterThan(0)
expect(queries.length, 'queries is empty — no envelope was inspected').toBeGreaterThan(0)
expect(keys.length,    'the key walk visited nothing, so it proves nothing').toBeGreaterThan(0)
```
The forbidden-key check is a recursive walk over objects **and** arrays (with its own tests proving it descends and returns `[]` on a leaf), asserted as `expect(found).toEqual([])` — not `not.toEqual(arrayContaining(...))`, which passes with one v3 key present.

## Proof each test fails without its fix

Reverted in place, run, restored:

| reverted | result |
|---|---|
| `platform.ts` → main | `expected '…/v1/paas/apps' to be '…/v1/platform/fleet'` |
| payload → v3 | **7 failed** — `retired v3 keys must not reach the wire: expected [ 'queryType', 'panelType', …] to deeply equal []` |
| `parseListRows` → v3 location | **8 failed** |
| `ApiError.endpoint` → `''` | **3 failed** |

```
pnpm vitest run  ->  258 files / 3221 tests passed, 1 file / 8 skipped
pnpm typecheck   ->  clean (tsc --noEmit, exit 0)
```
Baseline on main was 257 files / 3207 tests. The one skipped file (`blend-parity.test.ts`) is unrelated and skips identically before and after. `pnpm-lock.yaml` and `package.json` unchanged.

## Still broken — server-side, not fixable here

The **service-scoped** logs query (the per-product Logs sub-page) still returns:
```
500 {"error":"failed to get logs keys"}
```
`hanzoai/o11y` resolves field keys against `o11y_metadata` / `o11y_metrics`, databases that **do not exist** on the deployed store — `SHOW DATABASES` returns only `event`, and logs live in `event.log`. Any `filter`, `order` or `selectFields` hits it; bare `limit`/`offset` works. These are hardcoded package constants and **v1.5.59/v1.5.60 do not fix them**, so a version bump is not the answer. Detail and the ClickHouse query-log evidence are in hanzo-inc/cloud#387.

The console now sends the correct query and names the right door on the card. The org-wide Observe → Logs stream works today.

Branch only — not merged, not deployed.
